### PR TITLE
fixed type hints

### DIFF
--- a/rules-engine/pyproject.toml
+++ b/rules-engine/pyproject.toml
@@ -18,3 +18,7 @@ dev = [
 
 [tool.isort]
 profile = "black"
+
+[tool.mypy]
+disallow_any_generics = true
+disallow_incomplete_defs = true

--- a/rules-engine/src/rules_engine/engine.py
+++ b/rules-engine/src/rules_engine/engine.py
@@ -1,12 +1,5 @@
 import statistics as sts
-from typing import List, NamedTuple
-
-
-class EstimatesResult(NamedTuple):
-    bp: float
-    uas: List[float]
-    avg_ua: float
-    stdev_pct: float
+from typing import List, Tuple
 
 
 def hdd(avg_temp: float, balance_point: float) -> float:
@@ -86,7 +79,7 @@ def bp_ua_estimates(
     usages: List[float],
     initial_bp: float = 60,
     bp_sensitivity: float = 2,
-) -> EstimatesResult:
+) -> Tuple[float, List[float], float, float]:
     """Given a list of billing periods, returns an estimate of balance point,
     a list of UA coefficients for each period, and the average UA coefficient.
 
@@ -147,4 +140,4 @@ def bp_ua_estimates(
         else:
             directions_to_check.pop(0)
 
-    return EstimatesResult(bp, uas, avg_ua, stdev_pct)
+    return bp, uas, avg_ua, stdev_pct

--- a/rules-engine/src/rules_engine/engine.py
+++ b/rules-engine/src/rules_engine/engine.py
@@ -1,4 +1,12 @@
 import statistics as sts
+from typing import List, NamedTuple
+
+
+class EstimatesResult(NamedTuple):
+    bp: float
+    uas: List[float]
+    avg_ua: float
+    stdev_pct: float
 
 
 def hdd(avg_temp: float, balance_point: float) -> float:
@@ -17,7 +25,7 @@ def hdd(avg_temp: float, balance_point: float) -> float:
         return diff
 
 
-def period_hdd(avg_temps: list, balance_point: float) -> float:
+def period_hdd(avg_temps: List[float], balance_point: float) -> float:
     """Sum up total heating degree days in a given time period for a given home.
 
     Arguments:
@@ -74,11 +82,11 @@ def bp_ua_estimates(
     fuel_type: str,
     non_heat_usage: float,
     heat_sys_efficiency: float,
-    avg_temps_lists: list,
-    usages: list,
+    avg_temps_lists: List[List[float]],
+    usages: List[float],
     initial_bp: float = 60,
     bp_sensitivity: float = 2,
-):
+) -> EstimatesResult:
     """Given a list of billing periods, returns an estimate of balance point,
     a list of UA coefficients for each period, and the average UA coefficient.
 
@@ -139,4 +147,4 @@ def bp_ua_estimates(
         else:
             directions_to_check.pop(0)
 
-    return bp, uas, avg_ua, stdev_pct
+    return EstimatesResult(bp, uas, avg_ua, stdev_pct)


### PR DESCRIPTION
This PR:

* Adds value types for collections. e.g. instead of defining `list`, define `list[foo]`
* Defines return types for functions where they are missing
* Makes `mypy` a bit more strict, and add options to enforce the above

Closes #43 