### PR TITLE
Refine UA and balance point calculations through outlier detection

### DIFF
--- a/rules-engine/pyproject.toml
+++ b/rules-engine/pyproject.toml
@@ -6,7 +6,9 @@ build-backend = "setuptools.build_meta"
 name="rules-engine"
 version="0.0.1"
 requires-python=">=3.8"
-dependencies = []
+dependencies = [
+    "numpy"
+]
 
 [project.optional-dependencies]
 dev = [

--- a/rules-engine/requirements-dev.txt
+++ b/rules-engine/requirements-dev.txt
@@ -9,7 +9,9 @@ black==23.3.0
 click==8.1.3
     # via black
 colorama==0.4.6
-    # via pytest
+    # via
+    #   click
+    #   pytest
 exceptiongroup==1.1.1
     # via pytest
 iniconfig==2.0.0
@@ -22,6 +24,8 @@ mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
+numpy==1.24.4
+    # via rules-engine (pyproject.toml)
 packaging==23.1
     # via
     #   black

--- a/rules-engine/requirements.txt
+++ b/rules-engine/requirements.txt
@@ -4,3 +4,5 @@
 #
 #    pip-compile pyproject.toml
 #
+numpy==1.24.4
+    # via rules-engine (pyproject.toml)

--- a/rules-engine/src/rules_engine/engine.py
+++ b/rules-engine/src/rules_engine/engine.py
@@ -103,11 +103,6 @@ def bp_ua_estimates(
     initial_bp -- Balance point temperature in degrees F to try at first
     bp_sensitivity -- Degrees F to add/subtract from balance point when refining
     """
-
-    # this implementation assumes that the three list arguments are the same
-    # length, and also that the fuel_type string is valid. Not sure if this is
-    # the place to do that checking, or if it will be handled earlier
-
     bills_days = [len(l) for l in avg_temps_lists]
     avg_daily_heating_usages = [
         usage / days - non_heat_usage for usage, days in zip(usages, bills_days)
@@ -140,6 +135,8 @@ def bp_ua_estimates(
         # remove an outlier, recalculate stdev_pct, etc
         biggest_outlier_idx = np.argmax([abs(ua - avg_ua) for ua in uas])
         uas.pop(biggest_outlier_idx)  # removes the biggest outlier
+        avg_temps_lists.pop(biggest_outlier_idx)
+        partial_uas.pop(biggest_outlier_idx)
         avg_ua = sts.mean(uas)
         stdev_pct = sts.pstdev(uas) / avg_ua
         bp, uas, avg_ua, stdev_pct = recalculate_bp(
@@ -158,6 +155,9 @@ def recalculate_bp(
     partial_uas: List[float],
     uas: List[float],
 ) -> Tuple[float, List[float], float, float]:
+    """Tries different balance points plus or minus a given number of degrees,
+    choosing whichever one minimizes the standard deviation of the UAs.
+    """
     directions_to_check = [1, -1]
     bp = initial_bp
 

--- a/rules-engine/src/rules_engine/engine.py
+++ b/rules-engine/src/rules_engine/engine.py
@@ -90,7 +90,9 @@ class Home:
             self.bills.append(BillingPeriod(temps[i], usages[i], self))
 
     def calculate_balance_point_and_ua(
-        self, balance_point_sensitivity: float = 2
+        self,
+        balance_point_sensitivity: float = 2,
+        stdev_pct_max: float = 0.10,
     ) -> None:
         """Calculates the estimated balance point and UA coefficient for the home,
         removing UA outliers based on a normalized standard deviation threshold.
@@ -100,7 +102,7 @@ class Home:
         self.stdev_pct = sts.pstdev(self.uas) / self.avg_ua
         self.refine_balance_point(balance_point_sensitivity)
 
-        while self.stdev_pct > 0.10:
+        while self.stdev_pct > stdev_pct_max:
             biggest_outlier_idx = np.argmax(
                 [abs(bill.ua - self.avg_ua) for bill in self.bills]
             )
@@ -116,7 +118,7 @@ class Home:
             else:
                 self.uas, self.avg_ua, self.stdev_pct = uas_i, avg_ua_i, stdev_pct_i
 
-            self.refine_balance_point(0.5)
+            self.refine_balance_point(balance_point_sensitivity=0.5)
 
     def refine_balance_point(self, balance_point_sensitivity: float) -> None:
         """Tries different balance points plus or minus a given number of degrees,

--- a/rules-engine/src/rules_engine/engine.py
+++ b/rules-engine/src/rules_engine/engine.py
@@ -1,12 +1,13 @@
 import statistics as sts
-from typing import List, Tuple
 from enum import Enum
+from typing import List, Tuple
 
 import numpy as np
 
+
 class FuelType(Enum):
-    """Enum for fuel types. Values are BTU per usage
-    """""""""
+    """Enum for fuel types. Values are BTU per usage"""
+
     GAS = 100000
     OIL = 139600
     PROPANE = 91333
@@ -113,7 +114,7 @@ def bp_ua_estimates(
     ]
     period_hdds = [period_hdd(temps, initial_bp) for temps in avg_temps_lists]
 
-    bpu = fuel_type.value # the value in this case is the BTU per usage
+    bpu = fuel_type.value  # the value in this case is the BTU per usage
 
     uas = [
         ua(
@@ -157,7 +158,6 @@ def recalculate_bp(
     partial_uas: List[float],
     uas: List[float],
 ) -> Tuple[float, List[float], float, float]:
-
     directions_to_check = [1, -1]
     bp = initial_bp
 

--- a/rules-engine/src/rules_engine/engine.py
+++ b/rules-engine/src/rules_engine/engine.py
@@ -150,10 +150,10 @@ def recalculate_bp(
     bp_sensitivity: float,
     avg_ua: float,
     stdev_pct: float,
-    avg_temps_lists: list,
-    partial_uas: list,
-    uas: list,
-):
+    avg_temps_lists: List[float],
+    partial_uas: List[float],
+    uas: List[float],
+) -> Tuple[float, List[float], float, float]:
     directions_to_check = [1, -1]
     bp = initial_bp
 

--- a/rules-engine/src/rules_engine/engine.py
+++ b/rules-engine/src/rules_engine/engine.py
@@ -77,7 +77,7 @@ class Home:
         temps: List[List[float]],
         usages: List[float],
         avg_non_heating_usage: float = 0,
-    ):
+    ) -> None:
         """Eventually, this method should categorize the billing periods by
         season and calculate avg_non_heating_usage based on that. For now, we
         just pass in winter-only heating periods and manually define non-heating
@@ -89,7 +89,9 @@ class Home:
         for i in range(len(usages)):
             self.bills.append(BillingPeriod(temps[i], usages[i], self))
 
-    def calculate_balance_point_and_ua(self, balance_point_sensitivity: float = 2):
+    def calculate_balance_point_and_ua(
+        self, balance_point_sensitivity: float = 2
+    ) -> None:
         """Calculates the estimated balance point and UA coefficient for the home,
         removing UA outliers based on a normalized standard deviation threshold.
         """
@@ -116,7 +118,7 @@ class Home:
 
             self.refine_balance_point(0.5)
 
-    def refine_balance_point(self, balance_point_sensitivity: float):
+    def refine_balance_point(self, balance_point_sensitivity: float) -> None:
         """Tries different balance points plus or minus a given number of degrees,
         choosing whichever one minimizes the standard deviation of the UAs.
         """
@@ -169,10 +171,10 @@ class BillingPeriod:
             self.usage / self.days
         ) - self.home.avg_non_heating_usage
         self.total_hdd = period_hdd(self.avg_temps, self.home.balance_point)
-        self.partial_ua = self.partial_ua()
+        self.partial_ua = self.calculate_partial_ua()
         self.ua = self.partial_ua / self.total_hdd
 
-    def partial_ua(self):
+    def calculate_partial_ua(self):
         """The portion of UA that is not dependent on the balance point"""
         return (
             self.days

--- a/rules-engine/src/rules_engine/engine.py
+++ b/rules-engine/src/rules_engine/engine.py
@@ -5,14 +5,6 @@ from typing import List, Tuple
 import numpy as np
 
 
-class FuelType(Enum):
-    """Enum for fuel types. Values are BTU per usage"""
-
-    GAS = 100000
-    OIL = 139600
-    PROPANE = 91333
-
-
 def hdd(avg_temp: float, balance_point: float) -> float:
     """Calculate the heating degree days on a given day for a given home.
 
@@ -40,31 +32,6 @@ def period_hdd(avg_temps: List[float], balance_point: float) -> float:
     return sum([hdd(temp, balance_point) for temp in avg_temps])
 
 
-def ua(
-    days_in_period: int,
-    daily_heat_usage: float,
-    btu_per_usage: float,
-    heat_sys_efficiency: float,
-    p_hdd: float,
-) -> float:
-    """Computes the UA coefficient for a given billing period.
-
-    Arguments:
-    days_in_period -- number of days in the given billing period
-    daily_heat_usage -- average daily usage for heating during the period
-    btu_per_usage -- energy density constant for a given fuel type
-    heat_sys_efficiency -- heating system efficiency (decimal between 0 and 1)
-    p_hdd -- total number of heating degree days in the given period
-    """
-    return (
-        days_in_period
-        * daily_heat_usage
-        * btu_per_usage
-        * heat_sys_efficiency
-        / (p_hdd * 24)
-    )
-
-
 def average_indoor_temp(
     tstat_set: float, tstat_setback: float, setback_daily_hrs: float
 ) -> float:
@@ -82,100 +49,135 @@ def average_indoor_temp(
     ) / 24
 
 
+class FuelType(Enum):
+    """Enum for fuel types. Values are BTU per usage"""
+
+    GAS = 100000
+    OIL = 139600
+    PROPANE = 91333
+
+
+class Home:
+    """Defines attributes and methods for calculating home heat metrics"""
+
+    def __init__(
+        self,
+        fuel_type: FuelType,
+        heat_sys_efficiency: float,
+        initial_balance_point: float = 60,
+        thermostat_set_point: float = 68,
+    ):
+        self.fuel_type = fuel_type
+        self.heat_sys_efficiency = heat_sys_efficiency
+        self.balance_point = initial_balance_point
+        self.thermostat_set_point = thermostat_set_point
+
+    def initialize_billing_periods(
+        self,
+        temps: List[List[float]],
+        usages: List[float],
+        avg_non_heating_usage: float = 0,
+    ):
+        """Eventually, this method should categorize the billing periods by
+        season and calculate avg_non_heating_usage based on that. For now, we
+        just pass in winter-only heating periods and manually define non-heating
+        """
+        # assume for now that temps and usages have the same number of elements
+        self.bills = []
+        self.avg_non_heating_usage = avg_non_heating_usage
+
+        for i in range(len(usages)):
+            self.bills.append(BillingPeriod(temps[i], usages[i], self))
+
+    def calculate_balance_point_and_ua(self, balance_point_sensitivity: float = 2):
+        """Calculates the estimated balance point and UA coefficient for the home,
+        removing UA outliers based on a normalized standard deviation threshold.
+        """
+        self.uas = [bp.ua for bp in self.bills]
+        self.avg_ua = sts.mean(self.uas)
+        self.stdev_pct = sts.pstdev(self.uas) / self.avg_ua
+        self.refine_balance_point(balance_point_sensitivity)
+
+        while self.stdev_pct > 0.10:
+            biggest_outlier_idx = np.argmax(
+                [abs(bill.ua - self.avg_ua) for bill in self.bills]
+            )
+            outlier = self.bills.pop(biggest_outlier_idx)  # removes the biggest outlier
+            uas_i = [bp.ua for bp in self.bills]
+            avg_ua_i = sts.mean(uas_i)
+            stdev_pct_i = sts.pstdev(uas_i) / avg_ua_i
+            if self.stdev_pct - stdev_pct_i < 0.01:  # if it's a small enough change
+                self.bills.append(
+                    outlier
+                )  # then it's not worth removing it, and we exit
+                break  # may want some kind of warning to be raised as well
+            else:
+                self.uas, self.avg_ua, self.stdev_pct = uas_i, avg_ua_i, stdev_pct_i
+
+            self.refine_balance_point(0.5)
+
+    def refine_balance_point(self, balance_point_sensitivity: float):
+        """Tries different balance points plus or minus a given number of degrees,
+        choosing whichever one minimizes the standard deviation of the UAs.
+        """
+        directions_to_check = [1, -1]
+
+        while directions_to_check:
+            bp_i = (
+                self.balance_point + directions_to_check[0] * balance_point_sensitivity
+            )
+
+            if bp_i > self.thermostat_set_point:
+                break  # may want to raise some kind of warning as well
+
+            period_hdds_i = [period_hdd(bill.avg_temps, bp_i) for bill in self.bills]
+            uas_i = [
+                bill.partial_ua / period_hdds_i[n] for n, bill in enumerate(self.bills)
+            ]
+            avg_ua_i = sts.mean(uas_i)
+            stdev_pct_i = sts.pstdev(uas_i) / avg_ua_i
+
+            if stdev_pct_i < self.stdev_pct:
+                self.balance_point, self.avg_ua, self.stdev_pct = (
+                    bp_i,
+                    avg_ua_i,
+                    stdev_pct_i,
+                )
+
+                for n, bill in enumerate(self.bills):
+                    bill.total_hdd = period_hdds_i[n]
+                    bill.ua = uas_i[n]
+
+                if len(directions_to_check) == 2:
+                    directions_to_check.pop(-1)
+            else:
+                directions_to_check.pop(0)
+
+
 class BillingPeriod:
     def __init__(
         self,
         avg_temps: List[float],
         usage: float,
-        fuel_type: FuelType,
-        avg_non_heat_usage: float,
-        balance_point: float,
-        heat_sys_efficiency: float,
+        home: Home,
     ):
         self.avg_temps = avg_temps
         self.usage = usage
+        self.home = home
         self.days = len(self.avg_temps)
-        self.avg_heating_usage = (self.usage / self.days) - avg_non_heat_usage
-        self.total_hdd = period_hdd(self.avg_temps, balance_point)
-        self.ua = ua(
-            self.days,
-            self.avg_heating_usage,
-            fuel_type.value,
-            heat_sys_efficiency,
-            self.total_hdd,
+        self.avg_heating_usage = (
+            self.usage / self.days
+        ) - self.home.avg_non_heating_usage
+        self.total_hdd = period_hdd(self.avg_temps, self.home.balance_point)
+        self.partial_ua = self.partial_ua()
+        self.ua = self.partial_ua / self.total_hdd
+
+    def partial_ua(self):
+        """The portion of UA that is not dependent on the balance point"""
+        return (
+            self.days
+            * self.avg_heating_usage
+            * self.home.fuel_type.value
+            * self.home.heat_sys_efficiency
+            / 24
         )
-        self.partial_ua = self.ua * self.total_hdd
-
-
-def bp_ua_estimates(
-    billing_periods: List[BillingPeriod],
-) -> Tuple[float, List[float], float, float]:
-    """Given a list of billing periods, returns an estimate of balance point,
-    a list of UA coefficients for each period, and the average UA coefficient.
-
-    Arguments:
-    fuel_type -- heating fuel type in the home. One of "gas", "oil", "propane"
-    non_heat_usage -- estimate of daily non-heating fuel usage
-    heat_sys_efficiency -- heating system efficiency (decimal between 0 and 1)
-    avg_temps_lists -- list of lists of avg daily temps for each period
-    usages -- list of fuel usages (one for each period, same order as above)
-    initial_bp -- Balance point temperature in degrees F to try at first
-    bp_sensitivity -- Degrees F to add/subtract from balance point when refining
-    """
-    uas = [bp.ua for bp in billing_periods]
-    avg_ua = sts.mean(uas)
-    stdev_pct = sts.pstdev(uas) / avg_ua
-
-    bp, bills, avg_ua, stdev_pct = recalculate_bp(
-        58, 2, avg_ua, stdev_pct, billing_periods
-    )
-
-    # if the standard deviation of the UAs is below 10% / some threshold,
-    # then we can return what we have
-    while stdev_pct > 0.10:
-        # remove an outlier, recalculate stdev_pct, etc
-        biggest_outlier_idx = np.argmax([abs(bill.ua - avg_ua) for bill in bills])
-        outlier = bills.pop(biggest_outlier_idx)  # removes the biggest outlier
-        avg_ua_i = sts.mean(uas)
-        stdev_pct_i = sts.pstdev(uas) / avg_ua
-        if stdev_pct - stdev_pct_i < 0.01:
-            bills.append(outlier)
-            break  # may want some kind of warning to be raised as well
-
-        bp, bills, avg_ua, stdev_pct = recalculate_bp(bp, 0.5, avg_ua, stdev_pct, bills)
-
-    return bp, bills, avg_ua, stdev_pct
-
-
-def recalculate_bp(
-    initial_bp: float,
-    bp_sensitivity: float,
-    avg_ua: float,
-    stdev_pct: float,
-    bills: List[BillingPeriod],
-) -> Tuple[float, List[BillingPeriod], float, float]:
-    """Tries different balance points plus or minus a given number of degrees,
-    choosing whichever one minimizes the standard deviation of the UAs.
-    """
-    directions_to_check = [1, -1]
-    bp = initial_bp
-
-    while directions_to_check:
-        bp_i = bp + directions_to_check[0] * bp_sensitivity
-        period_hdds_i = [period_hdd(bill.avg_temps, bp_i) for bill in bills]
-        uas_i = [bill.partial_ua / period_hdds_i[n] for n, bill in enumerate(bills)]
-        avg_ua_i = sts.mean(uas_i)
-        stdev_pct_i = sts.pstdev(uas_i) / avg_ua_i
-        if stdev_pct_i < stdev_pct:
-            bp, avg_ua, stdev_pct = bp_i, avg_ua_i, stdev_pct_i
-
-            for n, bill in enumerate(bills):
-                bill.total_hdd = period_hdds_i[n]
-                bill.ua = uas_i[n]
-
-            if len(directions_to_check) == 2:
-                directions_to_check.pop(-1)
-        else:
-            directions_to_check.pop(0)
-
-    return bp, bills, avg_ua, stdev_pct

--- a/rules-engine/src/rules_engine/engine.py
+++ b/rules-engine/src/rules_engine/engine.py
@@ -175,7 +175,3 @@ def recalculate_bp(
             directions_to_check.pop(0)
 
     return bp, uas, avg_ua, stdev_pct
-
-
-# at some point, check to make sure BP does not go over the typical thermostat setting
-# this will need to produce an error that we can't calculate the heat load for that home

--- a/rules-engine/src/rules_engine/engine.py
+++ b/rules-engine/src/rules_engine/engine.py
@@ -1,4 +1,5 @@
 import statistics as sts
+
 import numpy as np
 
 
@@ -124,23 +125,34 @@ def bp_ua_estimates(
     avg_ua = sts.mean(uas)
     stdev_pct = sts.pstdev(uas) / avg_ua
 
-    bp, uas, avg_ua, stdev_pct = recalculate_bp(initial_bp, bp_sensitivity, avg_ua, avg_temps_lists, partial_uas, uas)
+    bp, uas, avg_ua, stdev_pct = recalculate_bp(
+        initial_bp, bp_sensitivity, avg_ua, stdev_pct, avg_temps_lists, partial_uas, uas
+    )
 
     # if the standard deviation of the UAs is below 10% / some threshold,
     # then we can return what we have
     while stdev_pct > 0.10:
         # remove an outlier, recalculate stdev_pct, etc
         biggest_outlier_idx = np.argmax([abs(ua - avg_ua) for ua in uas])
-        uas.pop(biggest_outlier_idx) # removes the biggest outlier
+        uas.pop(biggest_outlier_idx)  # removes the biggest outlier
         avg_ua = sts.mean(uas)
         stdev_pct = sts.pstdev(uas) / avg_ua
-        bp, uas, avg_ua, stdev_pct = recalculate_bp(bp, 0.5, avg_ua, avg_temps_lists, partial_uas, uas)
+        bp, uas, avg_ua, stdev_pct = recalculate_bp(
+            bp, 0.5, avg_ua, stdev_pct, avg_temps_lists, partial_uas, uas
+        )
 
     return bp, uas, avg_ua, stdev_pct
 
-    
-def recalculate_bp(initial_bp: float, bp_sensitivity: float, avg_ua: float,
-                   avg_temps_lists: list, partial_uas: list, uas: list):
+
+def recalculate_bp(
+    initial_bp: float,
+    bp_sensitivity: float,
+    avg_ua: float,
+    stdev_pct: float,
+    avg_temps_lists: list,
+    partial_uas: list,
+    uas: list,
+):
     directions_to_check = [1, -1]
     bp = initial_bp
 
@@ -156,7 +168,7 @@ def recalculate_bp(initial_bp: float, bp_sensitivity: float, avg_ua: float,
                 directions_to_check.pop(-1)
         else:
             directions_to_check.pop(0)
-    
+
     return bp, uas, avg_ua, stdev_pct
 
 

--- a/rules-engine/src/rules_engine/engine.py
+++ b/rules-engine/src/rules_engine/engine.py
@@ -94,7 +94,7 @@ class Home:
         initial_balance_point_sensitivity: float = 2,
         stdev_pct_max: float = 0.10,
         max_stdev_pct_diff: float = 0.01,
-        next_balance_point_sensitivity=0.5,
+        next_balance_point_sensitivity: float = 0.5,
     ) -> None:
         """Calculates the estimated balance point and UA coefficient for the home,
         removing UA outliers based on a normalized standard deviation threshold.

--- a/rules-engine/src/rules_engine/engine.py
+++ b/rules-engine/src/rules_engine/engine.py
@@ -1,7 +1,15 @@
 import statistics as sts
 from typing import List, Tuple
+from enum import Enum
 
 import numpy as np
+
+class FuelType(Enum):
+    """Enum for fuel types. Values are BTU per usage
+    """""""""
+    GAS = 100000
+    OIL = 139600
+    PROPANE = 91333
 
 
 def hdd(avg_temp: float, balance_point: float) -> float:
@@ -34,25 +42,25 @@ def period_hdd(avg_temps: List[float], balance_point: float) -> float:
 def ua(
     days_in_period: int,
     daily_heat_usage: float,
-    BTU_per_usage: float,
+    btu_per_usage: float,
     heat_sys_efficiency: float,
-    period_hdd: float,
+    p_hdd: float,
 ) -> float:
     """Computes the UA coefficient for a given billing period.
 
     Arguments:
     days_in_period -- number of days in the given billing period
     daily_heat_usage -- average daily usage for heating during the period
-    BTU_per_usage -- energy density constant for a given fuel type
+    btu_per_usage -- energy density constant for a given fuel type
     heat_sys_efficiency -- heating system efficiency (decimal between 0 and 1)
-    period_hdd -- total number of heating degree days in the given period
+    p_hdd -- total number of heating degree days in the given period
     """
     return (
         days_in_period
         * daily_heat_usage
-        * BTU_per_usage
+        * btu_per_usage
         * heat_sys_efficiency
-        / (period_hdd * 24)
+        / (p_hdd * 24)
     )
 
 
@@ -74,7 +82,7 @@ def average_indoor_temp(
 
 
 def bp_ua_estimates(
-    fuel_type: str,
+    fuel_type: FuelType,
     non_heat_usage: float,
     heat_sys_efficiency: float,
     avg_temps_lists: List[List[float]],
@@ -105,12 +113,7 @@ def bp_ua_estimates(
     ]
     period_hdds = [period_hdd(temps, initial_bp) for temps in avg_temps_lists]
 
-    btu_per_usage = {
-        "gas": 100000,  # usage in therms
-        "oil": 139600,  # usage in gallons
-        "propane": 91333,  # usage in gallons
-    }
-    bpu = btu_per_usage[fuel_type]
+    bpu = fuel_type.value # the value in this case is the BTU per usage
 
     uas = [
         ua(
@@ -150,10 +153,11 @@ def recalculate_bp(
     bp_sensitivity: float,
     avg_ua: float,
     stdev_pct: float,
-    avg_temps_lists: List[float],
+    avg_temps_lists: List[List[float]],
     partial_uas: List[float],
     uas: List[float],
 ) -> Tuple[float, List[float], float, float]:
+
     directions_to_check = [1, -1]
     bp = initial_bp
 
@@ -174,4 +178,4 @@ def recalculate_bp(
 
 
 # at some point, check to make sure BP does not go over the typical thermostat setting
-# at that point, this will need to produce an error that we can't calculate the heat load for that home
+# this will need to produce an error that we can't calculate the heat load for that home

--- a/rules-engine/src/rules_engine/engine.py
+++ b/rules-engine/src/rules_engine/engine.py
@@ -91,8 +91,10 @@ class Home:
 
     def calculate_balance_point_and_ua(
         self,
-        balance_point_sensitivity: float = 2,
+        initial_balance_point_sensitivity: float = 2,
         stdev_pct_max: float = 0.10,
+        max_stdev_pct_diff: float = 0.01,
+        next_balance_point_sensitivity=0.5,
     ) -> None:
         """Calculates the estimated balance point and UA coefficient for the home,
         removing UA outliers based on a normalized standard deviation threshold.
@@ -100,7 +102,7 @@ class Home:
         self.uas = [bp.ua for bp in self.bills]
         self.avg_ua = sts.mean(self.uas)
         self.stdev_pct = sts.pstdev(self.uas) / self.avg_ua
-        self.refine_balance_point(balance_point_sensitivity)
+        self.refine_balance_point(initial_balance_point_sensitivity)
 
         while self.stdev_pct > stdev_pct_max:
             biggest_outlier_idx = np.argmax(
@@ -110,7 +112,9 @@ class Home:
             uas_i = [bp.ua for bp in self.bills]
             avg_ua_i = sts.mean(uas_i)
             stdev_pct_i = sts.pstdev(uas_i) / avg_ua_i
-            if self.stdev_pct - stdev_pct_i < 0.01:  # if it's a small enough change
+            if (
+                self.stdev_pct - stdev_pct_i < max_stdev_pct_diff
+            ):  # if it's a small enough change
                 self.bills.append(
                     outlier
                 )  # then it's not worth removing it, and we exit
@@ -118,7 +122,7 @@ class Home:
             else:
                 self.uas, self.avg_ua, self.stdev_pct = uas_i, avg_ua_i, stdev_pct_i
 
-            self.refine_balance_point(balance_point_sensitivity=0.5)
+            self.refine_balance_point(next_balance_point_sensitivity)
 
     def refine_balance_point(self, balance_point_sensitivity: float) -> None:
         """Tries different balance points plus or minus a given number of degrees,

--- a/rules-engine/tests/rules_engine/test_engine.py
+++ b/rules-engine/tests/rules_engine/test_engine.py
@@ -70,11 +70,3 @@ def test_bp_ua_with_outlier():
     assert ua_3 == approx(1479.6, abs=1)
     assert home.avg_ua == approx(1515.1, abs=1)
     assert home.stdev_pct == approx(0.0474, abs=0.01)
-
-
-if __name__ == "__main__":
-    test_hdd()
-    test_period_hdd()
-    test_average_indoor_temp()
-    test_bp_ua_estimates()
-    test_bp_ua_with_outlier()

--- a/rules-engine/tests/rules_engine/test_engine.py
+++ b/rules-engine/tests/rules_engine/test_engine.py
@@ -44,7 +44,7 @@ def test_bp_ua_estimates():
     avg_temps_1 = [[28, 29, 30, 29], [32, 35, 35, 38], [41, 43, 42, 42]]
     usages_1 = [50, 45, 30]
     bp, uas, avg_ua, stdev_pct = engine.bp_ua_estimates(
-        "gas", 0.24, 0.88, avg_temps_1, usages_1, initial_bp=58
+        engine.FuelType.GAS, 0.24, 0.88, avg_temps_1, usages_1, initial_bp=58
     )
     ua_1, ua_2, ua_3 = uas
     assert bp == 60

--- a/rules-engine/tests/rules_engine/test_engine.py
+++ b/rules-engine/tests/rules_engine/test_engine.py
@@ -31,7 +31,9 @@ def test_average_indoor_temp():
 
 
 def test_bp_ua_estimates():
-    home = engine.Home(engine.FuelType.GAS, heat_sys_efficiency = 0.88, initial_balance_point = 58)
+    home = engine.Home(
+        engine.FuelType.GAS, heat_sys_efficiency=0.88, initial_balance_point=58
+    )
 
     daily_temps_lists = [[28, 29, 30, 29], [32, 35, 35, 38], [41, 43, 42, 42]]
     usages = [50, 45, 30]
@@ -48,7 +50,9 @@ def test_bp_ua_estimates():
 
 
 def test_bp_ua_with_outlier():
-    home = engine.Home(engine.FuelType.GAS, heat_sys_efficiency = 0.88, initial_balance_point = 58)
+    home = engine.Home(
+        engine.FuelType.GAS, heat_sys_efficiency=0.88, initial_balance_point=58
+    )
     daily_temps_lists = [
         [41.7, 41.6, 32, 25.4],
         [28, 29, 30, 29],

--- a/rules-engine/tests/rules_engine/test_engine.py
+++ b/rules-engine/tests/rules_engine/test_engine.py
@@ -41,12 +41,15 @@ def test_average_indoor_temp():
 
 
 def test_bp_ua_estimates():
-    avg_temps_1 = [[28, 29, 30, 29], [32, 35, 35, 38], [41, 43, 42, 42]]
-    usages_1 = [50, 45, 30]
-    bp, uas, avg_ua, stdev_pct = engine.bp_ua_estimates(
-        engine.FuelType.GAS, 0.24, 0.88, avg_temps_1, usages_1, initial_bp=58
-    )
-    ua_1, ua_2, ua_3 = uas
+    temps = [[28, 29, 30, 29], [32, 35, 35, 38], [41, 43, 42, 42]]
+    usages = [50, 45, 30]
+    billing_periods = [
+        engine.BillingPeriod(temps[i], usages[i], engine.FuelType.GAS, 0.24, 58, 0.88)
+        for i in range(len(usages))
+    ]
+    bp, bills, avg_ua, stdev_pct = engine.bp_ua_estimates(billing_periods)
+    ua_1, ua_2, ua_3 = [bill.ua for bill in bills]
+
     assert bp == 60
     assert ua_1 == approx(1450.5, abs=1)
     assert ua_2 == approx(1615.3, abs=1)
@@ -56,20 +59,20 @@ def test_bp_ua_estimates():
 
 
 def test_bp_ua_with_outlier():
-    avg_temps_1 = [
+    temps = [
         [41.7, 41.6, 32, 25.4],
         [28, 29, 30, 29],
         [32, 35, 35, 38],
         [41, 43, 42, 42],
     ]
-    usages_1 = [60, 50, 45, 30]
-    bp, uas, avg_ua, stdev_pct = engine.bp_ua_estimates(
-        engine.FuelType.GAS, 0.24, 0.88, avg_temps_1, usages_1, initial_bp=58
-    )
-    print(bp)
-    print(uas)
-    print(stdev_pct)
-    ua_1, ua_2, ua_3 = uas
+    usages = [60, 50, 45, 30]
+    billing_periods = [
+        engine.BillingPeriod(temps[i], usages[i], engine.FuelType.GAS, 0.24, 58, 0.88)
+        for i in range(len(usages))
+    ]
+    bp, bills, avg_ua, stdev_pct = engine.bp_ua_estimates(billing_periods)
+    ua_1, ua_2, ua_3 = [bill.ua for bill in bills]
+
     assert bp == 60
     assert ua_1 == approx(1450.5, abs=1)
     assert ua_2 == approx(1615.3, abs=1)

--- a/rules-engine/tests/rules_engine/test_engine.py
+++ b/rules-engine/tests/rules_engine/test_engine.py
@@ -20,16 +20,6 @@ def test_period_hdd():
     assert engine.period_hdd(temps_3, bp) == 0  # no days with HDDs
 
 
-def test_ua():
-    # I pulled the numbers for this test from the spreadsheet
-    bill_days, htg, p_hdd = 32, 6.92, 1015.9
-    btu_per_u = 100000
-    heat_eff = 0.88
-
-    ua_estimate = engine.ua(bill_days, htg, btu_per_u, heat_eff, p_hdd)
-    assert abs(ua_estimate - 799.4) < 0.2
-
-
 def test_average_indoor_temp():
     set_temp = 68
     setback = 62
@@ -41,50 +31,46 @@ def test_average_indoor_temp():
 
 
 def test_bp_ua_estimates():
-    temps = [[28, 29, 30, 29], [32, 35, 35, 38], [41, 43, 42, 42]]
-    usages = [50, 45, 30]
-    billing_periods = [
-        engine.BillingPeriod(temps[i], usages[i], engine.FuelType.GAS, 0.24, 58, 0.88)
-        for i in range(len(usages))
-    ]
-    bp, bills, avg_ua, stdev_pct = engine.bp_ua_estimates(billing_periods)
-    ua_1, ua_2, ua_3 = [bill.ua for bill in bills]
+    home = engine.Home(engine.FuelType.GAS, heat_sys_efficiency = 0.88, initial_balance_point = 58)
 
-    assert bp == 60
+    daily_temps_lists = [[28, 29, 30, 29], [32, 35, 35, 38], [41, 43, 42, 42]]
+    usages = [50, 45, 30]
+    home.initialize_billing_periods(daily_temps_lists, usages, 0.24)
+    home.calculate_balance_point_and_ua()
+    ua_1, ua_2, ua_3 = [bill.ua for bill in home.bills]
+
+    assert home.balance_point == 60
     assert ua_1 == approx(1450.5, abs=1)
     assert ua_2 == approx(1615.3, abs=1)
     assert ua_3 == approx(1479.6, abs=1)
-    assert avg_ua == approx(1515.1, abs=1)
-    assert stdev_pct == approx(0.0474, abs=0.01)
+    assert home.avg_ua == approx(1515.1, abs=1)
+    assert home.stdev_pct == approx(0.0474, abs=0.01)
 
 
 def test_bp_ua_with_outlier():
-    temps = [
+    home = engine.Home(engine.FuelType.GAS, heat_sys_efficiency = 0.88, initial_balance_point = 58)
+    daily_temps_lists = [
         [41.7, 41.6, 32, 25.4],
         [28, 29, 30, 29],
         [32, 35, 35, 38],
         [41, 43, 42, 42],
     ]
     usages = [60, 50, 45, 30]
-    billing_periods = [
-        engine.BillingPeriod(temps[i], usages[i], engine.FuelType.GAS, 0.24, 58, 0.88)
-        for i in range(len(usages))
-    ]
-    bp, bills, avg_ua, stdev_pct = engine.bp_ua_estimates(billing_periods)
-    ua_1, ua_2, ua_3 = [bill.ua for bill in bills]
+    home.initialize_billing_periods(daily_temps_lists, usages, 0.24)
+    home.calculate_balance_point_and_ua()
+    ua_1, ua_2, ua_3 = [bill.ua for bill in home.bills]
 
-    assert bp == 60
+    assert home.balance_point == 60
     assert ua_1 == approx(1450.5, abs=1)
     assert ua_2 == approx(1615.3, abs=1)
     assert ua_3 == approx(1479.6, abs=1)
-    assert avg_ua == approx(1515.1, abs=1)
-    assert stdev_pct == approx(0.0474, abs=0.01)
+    assert home.avg_ua == approx(1515.1, abs=1)
+    assert home.stdev_pct == approx(0.0474, abs=0.01)
 
 
 if __name__ == "__main__":
     test_hdd()
     test_period_hdd()
-    test_ua()
     test_average_indoor_temp()
     test_bp_ua_estimates()
     test_bp_ua_with_outlier()

--- a/rules-engine/tests/rules_engine/test_engine.py
+++ b/rules-engine/tests/rules_engine/test_engine.py
@@ -55,9 +55,33 @@ def test_bp_ua_estimates():
     assert stdev_pct == approx(0.0474, abs=0.01)
 
 
+def test_bp_ua_with_outlier():
+    avg_temps_1 = [
+        [41.7, 41.6, 32, 25.4],
+        [28, 29, 30, 29],
+        [32, 35, 35, 38],
+        [41, 43, 42, 42],
+    ]
+    usages_1 = [60, 50, 45, 30]
+    bp, uas, avg_ua, stdev_pct = engine.bp_ua_estimates(
+        engine.FuelType.GAS, 0.24, 0.88, avg_temps_1, usages_1, initial_bp=58
+    )
+    print(bp)
+    print(uas)
+    print(stdev_pct)
+    ua_1, ua_2, ua_3 = uas
+    assert bp == 60
+    assert ua_1 == approx(1450.5, abs=1)
+    assert ua_2 == approx(1615.3, abs=1)
+    assert ua_3 == approx(1479.6, abs=1)
+    assert avg_ua == approx(1515.1, abs=1)
+    assert stdev_pct == approx(0.0474, abs=0.01)
+
+
 if __name__ == "__main__":
     test_hdd()
     test_period_hdd()
     test_ua()
     test_average_indoor_temp()
     test_bp_ua_estimates()
+    test_bp_ua_with_outlier()


### PR DESCRIPTION
fixes #13 
fixes #49 
fixes #50 

To do: 
- [x] add outlier removal functionality
- [x] make sure requirements.txt reflects the addition of numpy to pyproject.toml
- [x] raise some kind of error if balance point goes as high as thermostat set point (meaning we can't produce a valid estimate for that home)
- [x] add a parameter for the minimum reduction in stdev percentage that makes the removal of an outlier worth it
- [x] consider making a BillingPeriod class which bundles together start date, end date, usage, etc
- [x] add some more tests