### PR TITLE
Added shared vscode test settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "rules-engine"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/rules-engine/.gitignore
+++ b/rules-engine/.gitignore
@@ -158,3 +158,16 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix

--- a/rules-engine/.gitignore
+++ b/rules-engine/.gitignore
@@ -158,6 +158,3 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
-
-# VSCode
-.vscode/


### PR DESCRIPTION
Including these settings configure common visual studio code setup for the project.  Specifically, these settings configure pytest, such that it is the vscode test runner.  Using these settings, the test panel in my vscode can be run:

![image](https://github.com/codeforboston/home-energy-analysis-tool/assets/12620443/27d1c6de-e066-43e7-aa65-a8598809527d)

I also updated the `.gitignore` configuration:

- I moved vscode related `.gitignore` settings to a repository-level `.gitignore` instead of under `rules-engine`
- I used the recommended `.gitignore` for [visual studio code](https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore).

