### PR TITLE
Added github action trigger

### DIFF
--- a/.github/workflows/test-rules-engine.yml
+++ b/.github/workflows/test-rules-engine.yml
@@ -1,6 +1,6 @@
 name: rules engine
 
-on: [push]
+on: [push, pull_request_target]
 
 env:
   working-directory: rules-engine


### PR DESCRIPTION
In tonight's session, we noticed that forks were not triggering GitHub workflows.  This additional trigger should make it so forks should trigger it.

See https://stackoverflow.com/a/63237162