### PR TITLE
Added parameterized tests

### DIFF
--- a/rules-engine/pyproject.toml
+++ b/rules-engine/pyproject.toml
@@ -25,3 +25,7 @@ profile = "black"
 [tool.mypy]
 disallow_any_generics = true
 disallow_incomplete_defs = true
+
+[[tool.mypy.overrides]]
+module = "parameterized.*"
+ignore_missing_imports = true

--- a/rules-engine/pyproject.toml
+++ b/rules-engine/pyproject.toml
@@ -15,7 +15,8 @@ dev = [
     "black",
     "isort",
     "mypy",
-    "pytest"
+    "parameterized",
+    "pytest",
 ]
 
 [tool.isort]

--- a/rules-engine/requirements-dev.txt
+++ b/rules-engine/requirements-dev.txt
@@ -9,9 +9,7 @@ black==23.3.0
 click==8.1.3
     # via black
 colorama==0.4.6
-    # via
-    #   click
-    #   pytest
+    # via pytest
 exceptiongroup==1.1.1
     # via pytest
 iniconfig==2.0.0
@@ -30,6 +28,8 @@ packaging==23.1
     # via
     #   black
     #   pytest
+parameterized==0.9.0
+    # via rules-engine (pyproject.toml)
 pathspec==0.11.1
     # via black
 platformdirs==3.7.0

--- a/rules-engine/tests/rules_engine/test_engine.py
+++ b/rules-engine/tests/rules_engine/test_engine.py
@@ -1,23 +1,25 @@
+from parameterized import parameterized
 from pytest import approx
 
 from rules_engine import engine
 
 
-def test_hdd():
-    assert engine.hdd(72, 60) == 0  # outside hotter than balance point
-    assert engine.hdd(60, 60) == 0  # outside equal to balance point
-    assert engine.hdd(57, 60) == 3  # outside cooler than balance point
+@parameterized([
+    (72, 60, 0), # outside hotter than balance point
+    (60, 60, 0), # outside equal to balance point
+    (57, 60, 3), # outside cooler than balance point
+])
+def test_hdd(avg_temp, balance_point, expected_result):
+    assert engine.hdd(avg_temp, balance_point) == expected_result
 
 
-def test_period_hdd():
-    bp = 60
-    temps_1 = [72, 60, 55, 61]
-    temps_2 = [52, 60, 55]
-    temps_3 = [72, 60, 65, 60, 80]
-
-    assert engine.period_hdd(temps_1, bp) == 5  # one day with HDDs
-    assert engine.period_hdd(temps_2, bp) == 13  # two days with HDDs
-    assert engine.period_hdd(temps_3, bp) == 0  # no days with HDDs
+@parameterized([
+    ([72, 60, 55, 61], 5), # one day with HDDs
+    ([52, 60, 55], 13), # two days with HDDs
+    ([72, 60, 65, 60, 80], 0), # no days with HDDs
+])
+def test_period_hdd(temps, expected_result):
+    assert engine.period_hdd(temps, 60) == expected_result
 
 
 def test_average_indoor_temp():

--- a/rules-engine/tests/rules_engine/test_engine.py
+++ b/rules-engine/tests/rules_engine/test_engine.py
@@ -4,20 +4,24 @@ from pytest import approx
 from rules_engine import engine
 
 
-@parameterized([
-    (72, 60, 0), # outside hotter than balance point
-    (60, 60, 0), # outside equal to balance point
-    (57, 60, 3), # outside cooler than balance point
-])
+@parameterized(
+    [
+        (72, 60, 0),  # outside hotter than balance point
+        (60, 60, 0),  # outside equal to balance point
+        (57, 60, 3),  # outside cooler than balance point
+    ]
+)
 def test_hdd(avg_temp, balance_point, expected_result):
     assert engine.hdd(avg_temp, balance_point) == expected_result
 
 
-@parameterized([
-    ([72, 60, 55, 61], 5), # one day with HDDs
-    ([52, 60, 55], 13), # two days with HDDs
-    ([72, 60, 65, 60, 80], 0), # no days with HDDs
-])
+@parameterized(
+    [
+        ([72, 60, 55, 61], 5),  # one day with HDDs
+        ([52, 60, 55], 13),  # two days with HDDs
+        ([72, 60, 65, 60, 80], 0),  # no days with HDDs
+    ]
+)
 def test_period_hdd(temps, expected_result):
     assert engine.period_hdd(temps, 60) == expected_result
 


### PR DESCRIPTION
Related to #10

As we explore introducing more test cases for existing functions, I thought it might be useful to bring in `parameterized`, a simple test parameterization library.  My rationale is:

1. it does a better job with test parameterization than the basic `pytest.mark.parameterize` with simpler syntax
2. it has simple ways of parameterizing tests from files too, see a few of the examples here: https://github.com/wolever/parameterized#exhaustive-usage-examples