### PR TITLE
Use pytest instead of parameterized

### DIFF
--- a/rules-engine/pyproject.toml
+++ b/rules-engine/pyproject.toml
@@ -15,7 +15,6 @@ dev = [
     "black",
     "isort",
     "mypy",
-    "parameterized",
     "pytest",
 ]
 
@@ -25,7 +24,3 @@ profile = "black"
 [tool.mypy]
 disallow_any_generics = true
 disallow_incomplete_defs = true
-
-[[tool.mypy.overrides]]
-module = "parameterized.*"
-ignore_missing_imports = true

--- a/rules-engine/requirements-dev.txt
+++ b/rules-engine/requirements-dev.txt
@@ -28,8 +28,6 @@ packaging==23.1
     # via
     #   black
     #   pytest
-parameterized==0.9.0
-    # via rules-engine (pyproject.toml)
 pathspec==0.11.1
     # via black
 platformdirs==3.7.0

--- a/rules-engine/tests/rules_engine/test_engine.py
+++ b/rules-engine/tests/rules_engine/test_engine.py
@@ -1,26 +1,28 @@
-from parameterized import parameterized
+import pytest
 from pytest import approx
 
 from rules_engine import engine
 
 
-@parameterized(
+@pytest.mark.parametrize(
+    "avg_temp, balance_point, expected_result",
     [
         (72, 60, 0),  # outside hotter than balance point
         (60, 60, 0),  # outside equal to balance point
         (57, 60, 3),  # outside cooler than balance point
-    ]
+    ],
 )
 def test_hdd(avg_temp, balance_point, expected_result):
     assert engine.hdd(avg_temp, balance_point) == expected_result
 
 
-@parameterized(
+@pytest.mark.parametrize(
+    "temps, expected_result",
     [
         ([72, 60, 55, 61], 5),  # one day with HDDs
         ([52, 60, 55], 13),  # two days with HDDs
         ([72, 60, 65, 60, 80], 0),  # no days with HDDs
-    ]
+    ],
 )
 def test_period_hdd(temps, expected_result):
     assert engine.period_hdd(temps, 60) == expected_result


### PR DESCRIPTION
Unfortunately the `parameterized` library hasn't been updated to support more modern versions of `pytest`.  Swap it out for `pytest.mark.parametrize`.