### PR TITLE
Add example to try out pyodide importing modules

### DIFF
--- a/rules-engine/src/rules_engine/import_test_1.py
+++ b/rules-engine/src/rules_engine/import_test_1.py
@@ -5,6 +5,7 @@ Once that testing is complete, this module should be deleted.
 
 from . import import_test_2
 
+
 def try_it_out() -> bool:
     foo = import_test_2.Foo()
     foo.call_me()

--- a/rules-engine/src/rules_engine/import_test_1.py
+++ b/rules-engine/src/rules_engine/import_test_1.py
@@ -1,0 +1,11 @@
+"""
+TODO: this module was created to test importing via Pyodide.
+Once that testing is complete, this module should be deleted.
+"""
+
+from . import import_test_2
+
+def try_it_out() -> bool:
+    foo = import_test_2.Foo()
+    foo.call_me()
+    return True

--- a/rules-engine/src/rules_engine/import_test_2.py
+++ b/rules-engine/src/rules_engine/import_test_2.py
@@ -1,0 +1,8 @@
+"""
+TODO: this module was created to test importing via Pyodide.
+Once that testing is complete, this module should be deleted.
+"""
+
+class Foo:
+    def call_me(self):
+        print("I was called!")

--- a/rules-engine/src/rules_engine/import_test_2.py
+++ b/rules-engine/src/rules_engine/import_test_2.py
@@ -3,6 +3,7 @@ TODO: this module was created to test importing via Pyodide.
 Once that testing is complete, this module should be deleted.
 """
 
+
 class Foo:
     def call_me(self):
         print("I was called!")


### PR DESCRIPTION
This PR adds an example to help try out Pyodide loading across files / modules.  To try it out:

* Load the `import_test_1.py` module.
* Call `import_test_1.try_it_out()` and see what happens!
* If nothing blows up, we should be able to use the same pattern (multiple modules) in the main engine.
* We can then clean up these files.

Part of #53 