### PR TITLE
Added wheel step to CI

### DIFF
--- a/.github/workflows/test-rules-engine.yml
+++ b/.github/workflows/test-rules-engine.yml
@@ -71,3 +71,18 @@ jobs:
       - name: Run tests
         run: |
           pydocstyle .
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up environment
+        uses: "./.github/actions/setup-rules-engine"
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Build wheel
+        run: |
+          python -m build

--- a/.github/workflows/test-rules-engine.yml
+++ b/.github/workflows/test-rules-engine.yml
@@ -85,4 +85,5 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Build wheel
         run: |
+          pip install -q build
           python -m build


### PR DESCRIPTION
This PR adds building a wheel to CI's standard checks for the rules engine.  We still need to figure out the right way to deliver this wheel to the front end, but this first step adds a check that we are always in a buildable state.

Part of #88 .