### PR TITLE
Start adding case routes

### DIFF
--- a/heat-stack/app/root.tsx
+++ b/heat-stack/app/root.tsx
@@ -5,7 +5,7 @@ import {
 	json,
 	type LinksFunction,
 } from '@remix-run/node'
-import { Links, Scripts } from '@remix-run/react'
+import { Links, Scripts, Outlet } from '@remix-run/react'
 import { CaseSummary } from './components/CaseSummary.tsx'
 import { href as iconsHref } from './components/ui/icon.tsx'
 import fontStyleSheetUrl from './styles/font.css'
@@ -125,8 +125,11 @@ export const headers: HeadersFunction = ({ loaderHeaders, parentHeaders }) => {
 	}
 }
 
-export default function HeatStack({ env = {} }) {
-	const nonce = useNonce()
+export default function HeatStack({ children, env = {}, nonce }: {
+	children: React.ReactNode
+	nonce: string
+	env?: Record<string, string>
+}) {
 	return (
 		<html lang="en" className={`${'light'} h-full overflow-x-hidden`}>
 			<head>
@@ -135,7 +138,14 @@ export default function HeatStack({ env = {} }) {
 				<Links />
 			</head>
 			<body className="bg-background text-foreground">
+				
+				<h1>Title</h1>
+				
+				<Outlet />
 				<CaseSummary />
+
+				<div>Footer</div>
+				
 				<script
 					nonce={nonce}
 					dangerouslySetInnerHTML={{
@@ -147,3 +157,5 @@ export default function HeatStack({ env = {} }) {
 		</html>
 	)
 }
+
+// <CaseSummary />

--- a/heat-stack/app/routes/cases+/$analysisid.tsx
+++ b/heat-stack/app/routes/cases+/$analysisid.tsx
@@ -1,0 +1,35 @@
+import { json, type DataFunctionArgs } from '@remix-run/node'
+import { Outlet, useLoaderData } from '@remix-run/react'
+import { Fragment } from 'react'
+
+export async function loader({ params }: DataFunctionArgs) {
+    // // From the database:
+	// const user = await prisma.user.findFirst({
+	// 	select: {
+	// 		id: true,
+	// 		name: true,
+	// 		username: true,
+	// 		createdAt: true,
+	// 		image: { select: { id: true } },
+	// 	},
+	// 	where: {
+	// 		username: params.username,
+	// 	},
+	// })
+    
+    return json({
+        id: params.analysisid
+        })
+}
+
+export default function Analysis () {
+	const data = useLoaderData<typeof loader>()
+    const id = data?.id
+
+    return (
+        <Fragment>
+            <h1>{ id }</h1>
+            {/* <Outlet /> */}
+        </Fragment>
+    )
+}

--- a/heat-stack/app/routes/cases+/case_summaries+/$summaryid_+/index.tsx
+++ b/heat-stack/app/routes/cases+/case_summaries+/$summaryid_+/index.tsx
@@ -1,0 +1,10 @@
+import { Outlet } from '@remix-run/react'
+
+export default function Cases() {
+    return(
+        <div className="w-100p h-100p bk-primary">
+            <h1>Case name</h1>
+            <Outlet/>
+        </div>
+    )
+}

--- a/heat-stack/app/routes/cases+/index.tsx
+++ b/heat-stack/app/routes/cases+/index.tsx
@@ -1,0 +1,11 @@
+export default function Cases() {
+    return(
+        <div className="w-96 bg-slate-400 ">
+            <h1>Cases</h1>
+            <ul>
+                <li>Case 1</li>
+                <li>Case 2</li>
+            </ul>
+        </div>
+    )
+}


### PR DESCRIPTION
This PR it keeps the `root.tsx` as we had it but adds an `<Outlet/>` so it shows:
- the index.tsx from `_marketing/index.tsx` on the `/` page (since the `_` prefix indicates it’s not a real routing folder),
- a static page on `/cases/`,
- and the case number `123` on `/cases/123` , that is literally it just prints `123` or whatever variable is in the route for now.

Because `<CaseSummary/>` was retained on `root.tsx` for now, it always displays. I believe @jkoren has a revision that moves that to a subroute which will be done after this one.

See also:
- <a href="https://github.com/epicweb-dev/epic-stack/blob/main/docs/routing.md">Epic Stack Routing opinion explanation</a>

##  [remix-flat-routes](https://github.com/kiliman/remix-flat-routes) File system routing conventions [(full doc link)](https://gist.github.com/ryanflorence/0dcc52c2332c2f6e1b52925195f87baf )
- *(Note these filenames are examples from the conventions document, not this project)*
- **If you're familiar with the Remix routing convention, just think of it this way, `remix-flat-routes` converts `+/` (that is, folder ending in plus sign) to `.`.**
- "Layout" refers to how the parent layouts should apply.

| filename                | convention             | behavior                        |
| ----------------------- | ---------------------- | ------------------------------- |
| `privacy.jsx`           | filename               | normal route                    |
| `pages.tos.jsx`         | dot with no layout     | normal route, "." -> "/"        |
| `about.jsx`             | filename with children | parent layout route             |
| `about.contact.jsx`     | dot                    | child route of layout           |
| `about.index.jsx`       | index filename         | index route of layout           |
| `about_.company.jsx`    | trailing underscore    | url segment, no layout          |
| `_auth.jsx`             | leading underscore     | layout nesting, no url segment  |
| `_auth.login.jsx`       | leading underscore     | child of pathless layout route  |
| `users.$userId.jsx`     | leading $              | URL param                       |
| `docs.$.jsx`            | bare $                 | splat route                     |
| `dashboard.route.jsx`   | route suffix           | optional, ignored completely    |
| `investors/[index].jsx` | brackets               | escapes conventional characters |


## Routes folder in this early PR version:

```bash
➜ tree heat-stack/app/routes
heat-stack/app/routes
├── $.tsx # splat route: if no other routes match, this one will
├── _auth+ #route as /...   ; leading _ means layout nesting, no url segment; remix-flat-routes converts +/ to .
│   ├── auth.$provider.callback.test.ts
│   ├── auth.$provider.callback.ts
│   ├── auth.$provider.ts
│   ├── forgot-password.tsx
│   ├── login.tsx # route as /login
│   ├── logout.tsx
│   ├── onboarding.tsx
│   ├── onboarding_.$provider.tsx
│   ├── reset-password.tsx
│   ├── signup.tsx # route as /signup
│   └── verify.tsx
├── _marketing+ #route as /...  ; leading _ means layout nesting, no url segment; remix-flat-routes converts +/ to .
│   ├── about.tsx # route as /about components appear in <outlet/> on root.tsx
│   ├── index.tsx # this appears in <outlet/> on root.tsx when at /
│   ├── logos # svg's, no code
│   ├── privacy.tsx
│   ├── support.tsx
│   └── tos.tsx
├── _seo+ #leading _ means layout nesting, no url segment; remix-flat-routes converts +/ to .
│   ├── robots[.]txt.ts
│   └── sitemap[.]xml.ts
├── admin+ #route all like /admin/... because remix-flat-routes converts +/ to .
│   ├── cache.tsx
│   ├── cache_.lru.$cacheKey.ts
│   ├── cache_.sqlite.$cacheKey.ts
│   └── cache_.sqlite.tsx
├── cases+ # routes as /cases/... because remix-flat-routes converts +/ to .
│   ├── $analysisid.tsx # routes as /cases/123
│   ├── case_summaries+ 
│   │   └── $summaryid_+
│   │       └── index.tsx # routes as /cases/case_summaries/123/ (not sure?)
│   └── index.tsx
├── me.tsx # routes like `/me` and code does redirect(`/users/${user.username}`)
├── resources+ #route contents like /resources/...  because remix-flat-routes converts +/ to .
│   ├── download-user-data.tsx
│   ├── healthcheck.tsx
│   ├── note-images.$imageId.tsx
│   └── user-images.$imageId.tsx
├── settings+ #route contents like /settings/... because remix-flat-routes converts +/ to .
│   ├── profile.change-email.tsx # routes like /settings/profile/change-email
│   ├── profile.connections.tsx
│   ├── profile.index.tsx # /settings/profile (we can call this profile's index route—will be surrounded by profile.tsx layout)
│   ├── profile.password.tsx
│   ├── profile.password_.create.tsx
│   ├── profile.photo.tsx
│   ├── profile.tsx # /settings/profile (we can call this a layout—it has <Outlet/>
│   ├── profile.two-factor.disable.tsx # routes like /settings/two-factor/disable
│   ├── profile.two-factor.index.tsx
│   ├── profile.two-factor.tsx
│   └── profile.two-factor.verify.tsx
└── users+ #route contents like /users/
    ├── $username.test.tsx # is a test, not routed?
    ├── $username.tsx 
    ├── $username_+ #routes like /users/kody/...
    │   ├── __note-editor.tsx
    │   ├── notes.$noteId.tsx
    │   ├── notes.$noteId_.edit.tsx # routes like /users/kody/notes/123/edit
    │   ├── notes.index.tsx # routes like /users/kody/notes
    │   ├── notes.new.tsx
    │   └── notes.tsx # routes like /users/kody/notes
    └── index.tsx
```