### PR TITLE
Updated code to fix rules_engine tests such that they all pass

### DIFF
--- a/rules-engine/src/rules_engine/engine.py
+++ b/rules-engine/src/rules_engine/engine.py
@@ -45,7 +45,7 @@ def get_outputs_oil_propane(
                 period_start_date=start_date,
                 period_end_date=input_val.period_end_date,
                 usage=input_val.gallons,
-                inclusion_override=inclusion,
+                analysis_type_override=inclusion,
             )
         )
         last_date = input_val.period_end_date
@@ -68,7 +68,7 @@ def get_outputs_natural_gas(
                 period_start_date=input_val.period_start_date,
                 period_end_date=input_val.period_end_date,
                 usage=input_val.usage_therms,
-                inclusion_override=input_val.inclusion_override,
+                analysis_type_override=input_val.inclusion_override,
             )
         )
 
@@ -171,8 +171,8 @@ def convert_to_intermediate_billing_periods(
         )
 
         analysis_type = date_to_analysis_type(billing_period.period_end_date)
-        if billing_period.inclusion_override:
-            analysis_type = billing_period.inclusion_override
+        if billing_period.analysis_type_override:
+            analysis_type = billing_period.analysis_type_override
 
         intermediate_billing_period = BillingPeriod(
             input=billing_period,

--- a/rules-engine/src/rules_engine/pydantic_models.py
+++ b/rules-engine/src/rules_engine/pydantic_models.py
@@ -114,7 +114,7 @@ class NormalizedBillingPeriodRecordInput(BaseModel):
     analysis_type_override: Optional[AnalysisType]  # for testing only
 
 
-class NormalizedBillingPeriodRecord:
+class NormalizedBillingPeriodRecord(BaseModel):
     input: NormalizedBillingPeriodRecordInput
     analysis_type: AnalysisType
     default_inclusion_by_calculation: bool
@@ -167,7 +167,7 @@ class BalancePointGraph(BaseModel):
     records: List[BalancePointGraphRow]
 
 
-class RulesEngineResult:
+class RulesEngineResult(BaseModel):
     summary_output: SummaryOutput
     balance_point_graph: BalancePointGraph
     billing_records: List[NormalizedBillingPeriodRecord]

--- a/rules-engine/tests/test_rules_engine/test_engine.py
+++ b/rules-engine/tests/test_rules_engine/test_engine.py
@@ -21,12 +21,13 @@ from rules_engine.pydantic_models import (
 @pytest.fixture()
 def sample_billing_periods() -> list[engine.BillingPeriod]:
     billing_periods = [
-        engine.BillingPeriod([28, 29, 30, 29], 50, AnalysisType.ALLOWED_HEATING_USAGE),
-        engine.BillingPeriod([32, 35, 35, 38], 45, AnalysisType.ALLOWED_HEATING_USAGE),
-        engine.BillingPeriod([41, 43, 42, 42], 30, AnalysisType.ALLOWED_HEATING_USAGE),
-        engine.BillingPeriod(
-            [72, 71, 70, 69], 0.96, AnalysisType.NOT_ALLOWED_IN_CALCULATIONS
-        ),
+        
+        # Not sure if this is the right thing to do here, but I (ErikS) added None as first argument to fix positional argument type errors
+
+        engine.BillingPeriod(None, [28, 29, 30, 29], 50, AnalysisType.ALLOWED_HEATING_USAGE),
+        engine.BillingPeriod(None, [32, 35, 35, 38], 45, AnalysisType.ALLOWED_HEATING_USAGE),
+        engine.BillingPeriod(None, [41, 43, 42, 42], 30, AnalysisType.ALLOWED_HEATING_USAGE),
+        engine.BillingPeriod(None, [72, 71, 70, 69], 0.96, AnalysisType.NOT_ALLOWED_IN_CALCULATIONS)
     ]
     return billing_periods
 
@@ -34,15 +35,14 @@ def sample_billing_periods() -> list[engine.BillingPeriod]:
 @pytest.fixture()
 def sample_billing_periods_with_outlier() -> list[engine.BillingPeriod]:
     billing_periods = [
-        engine.BillingPeriod(
-            [41.7, 41.6, 32, 25.4], 60, AnalysisType.ALLOWED_HEATING_USAGE
-        ),
-        engine.BillingPeriod([28, 29, 30, 29], 50, AnalysisType.ALLOWED_HEATING_USAGE),
-        engine.BillingPeriod([32, 35, 35, 38], 45, AnalysisType.ALLOWED_HEATING_USAGE),
-        engine.BillingPeriod([41, 43, 42, 42], 30, AnalysisType.ALLOWED_HEATING_USAGE),
-        engine.BillingPeriod(
-            [72, 71, 70, 69], 0.96, AnalysisType.NOT_ALLOWED_IN_CALCULATIONS
-        ),
+
+        # Not sure if this is the right thing to do here, but I (ErikS) added None as first argument to fix positional argument type errors
+
+        engine.BillingPeriod(None, [41.7, 41.6, 32, 25.4], 60, AnalysisType.ALLOWED_HEATING_USAGE),
+        engine.BillingPeriod(None, [28, 29, 30, 29], 50, AnalysisType.ALLOWED_HEATING_USAGE),
+        engine.BillingPeriod(None, [32, 35, 35, 38], 45, AnalysisType.ALLOWED_HEATING_USAGE),
+        engine.BillingPeriod(None, [41, 43, 42, 42], 30, AnalysisType.ALLOWED_HEATING_USAGE),
+        engine.BillingPeriod(None, [72, 71, 70, 69], 0.96, AnalysisType.NOT_ALLOWED_IN_CALCULATIONS)
     ]
 
     return billing_periods
@@ -129,31 +129,31 @@ def sample_normalized_billing_periods() -> list[NormalizedBillingPeriodRecordInp
             "period_start_date": "2022-12-01",
             "period_end_date": "2022-12-04",
             "usage": 60,
-            "inclusion_override": None,
+            "analysis_type_override": None,
         },
         {
             "period_start_date": "2023-01-01",
             "period_end_date": "2023-01-04",
             "usage": 50,
-            "inclusion_override": None,
+            "analysis_type_override": None,
         },
         {
             "period_start_date": "2023-02-01",
             "period_end_date": "2023-02-04",
             "usage": 45,
-            "inclusion_override": None,
+            "analysis_type_override": None,
         },
         {
             "period_start_date": "2023-03-01",
             "period_end_date": "2023-03-04",
             "usage": 30,
-            "inclusion_override": None,
+            "analysis_type_override": None,
         },
         {
             "period_start_date": "2023-04-01",
             "period_end_date": "2023-04-04",
             "usage": 0.96,
-            "inclusion_override": None,
+            "analysis_type_override": None,
         },
     ]
 
@@ -261,15 +261,14 @@ def test_convert_to_intermediate_billing_periods(
     )
 
     expected_results = [
-        engine.BillingPeriod(
-            [41.7, 41.6, 32, 25.4], 60, AnalysisType.ALLOWED_HEATING_USAGE
-        ),
-        engine.BillingPeriod([28, 29, 30, 29], 50, AnalysisType.ALLOWED_HEATING_USAGE),
-        engine.BillingPeriod([32, 35, 35, 38], 45, AnalysisType.ALLOWED_HEATING_USAGE),
-        engine.BillingPeriod([41, 43, 42, 42], 30, AnalysisType.ALLOWED_HEATING_USAGE),
-        engine.BillingPeriod(
-            [72, 71, 70, 69], 0.96, AnalysisType.NOT_ALLOWED_IN_CALCULATIONS
-        ),
+
+        # Not sure if this is the right thing to do here, but I (ErikS) added None as first argument to fix positional argument type errors
+
+        engine.BillingPeriod(None, [41.7, 41.6, 32, 25.4], 60, AnalysisType.ALLOWED_HEATING_USAGE),
+        engine.BillingPeriod(None, [28, 29, 30, 29], 50, AnalysisType.ALLOWED_HEATING_USAGE),
+        engine.BillingPeriod(None, [32, 35, 35, 38], 45, AnalysisType.ALLOWED_HEATING_USAGE),
+        engine.BillingPeriod(None, [41, 43, 42, 42], 30, AnalysisType.ALLOWED_HEATING_USAGE),
+        engine.BillingPeriod(None, [72, 71, 70, 69], 0.96, AnalysisType.NOT_ALLOWED_IN_CALCULATIONS)
     ]
 
     for i in range(len(expected_results)):
@@ -284,16 +283,16 @@ def test_convert_to_intermediate_billing_periods(
 def test_get_outputs_normalized(
     sample_summary_inputs, sample_temp_inputs, sample_normalized_billing_periods
 ):
-    summary_output = engine.get_outputs_normalized(
+    rules_engine_result = engine.get_outputs_normalized(
         sample_summary_inputs,
         None,
         sample_temp_inputs,
         sample_normalized_billing_periods,
     )
 
-    assert summary_output.estimated_balance_point == 60.5
-    assert summary_output.whole_home_heat_loss_rate == approx(1519.72, abs=1)
-    assert summary_output.standard_deviation_of_heat_loss_rate == approx(
+    assert rules_engine_result.summary_output.estimated_balance_point == 60.5
+    assert rules_engine_result.summary_output.whole_home_heat_loss_rate == approx(1519.72, abs=1)
+    assert rules_engine_result.summary_output.standard_deviation_of_heat_loss_rate == approx(
         0.0463, abs=0.01
     )
 

--- a/rules-engine/tests/test_rules_engine/test_examples.py
+++ b/rules-engine/tests/test_rules_engine/test_examples.py
@@ -114,63 +114,63 @@ def test_average_indoor_temp(data: Example) -> None:
 
 
 def test_balance_point_natural_gas(data: Example) -> None:
-    summary_output = engine.get_outputs_natural_gas(
+    rules_engine_result = engine.get_outputs_natural_gas(
         data.summary, data.temperature_data, data.natural_gas_usage
     )
     assert data.summary.estimated_balance_point == approx(
-        summary_output.estimated_balance_point, abs=0.1
+        rules_engine_result.summary_output.estimated_balance_point, abs=0.1
     )
 
 
 def test_whole_home_heat_loss_rate_natural_gas(data: Example) -> None:
-    summary_output = engine.get_outputs_natural_gas(
+    rules_engine_result = engine.get_outputs_natural_gas(
         data.summary, data.temperature_data, data.natural_gas_usage
     )
-    assert summary_output.whole_home_heat_loss_rate == approx(
+    assert rules_engine_result.summary_output.whole_home_heat_loss_rate == approx(
         data.summary.whole_home_heat_loss_rate, abs=1
     )
 
 
 def test_standard_deviation_of_heat_loss_rate_natural_gas(data: Example) -> None:
-    summary_output = engine.get_outputs_natural_gas(
+    rules_engine_result = engine.get_outputs_natural_gas(
         data.summary, data.temperature_data, data.natural_gas_usage
     )
-    assert summary_output.standard_deviation_of_heat_loss_rate == approx(
+    assert rules_engine_result.summary_output.standard_deviation_of_heat_loss_rate == approx(
         data.summary.standard_deviation_of_heat_loss_rate, abs=0.01
     )
 
 
 def test_difference_between_ti_and_tbp_natural_gas(data: Example) -> None:
-    summary_output = engine.get_outputs_natural_gas(
+    rules_engine_result = engine.get_outputs_natural_gas(
         data.summary, data.temperature_data, data.natural_gas_usage
     )
-    assert summary_output.difference_between_ti_and_tbp == approx(
+    assert rules_engine_result.summary_output.difference_between_ti_and_tbp == approx(
         data.summary.difference_between_ti_and_tbp, abs=0.1
     )
 
 
 def test_average_heat_load_natural_gas(data: Example) -> None:
-    summary_output = engine.get_outputs_natural_gas(
+    rules_engine_result = engine.get_outputs_natural_gas(
         data.summary, data.temperature_data, data.natural_gas_usage
     )
-    assert summary_output.average_heat_load == approx(
+    assert rules_engine_result.summary_output.average_heat_load == approx(
         data.summary.average_heat_load, abs=1
     )
 
 
 def test_design_temperaure_natural_gas(data: Example) -> None:
-    summary_output = engine.get_outputs_natural_gas(
+    rules_engine_result = engine.get_outputs_natural_gas(
         data.summary, data.temperature_data, data.natural_gas_usage
     )
-    assert summary_output.design_temperature == approx(
+    assert rules_engine_result.summary_output.design_temperature == approx(
         data.summary.design_temperature, abs=0.1
     )
 
 
 def test_maximum_heat_load_natural_gas(data: Example) -> None:
-    summary_output = engine.get_outputs_natural_gas(
+    rules_engine_result = engine.get_outputs_natural_gas(
         data.summary, data.temperature_data, data.natural_gas_usage
     )
-    assert summary_output.maximum_heat_load == approx(
+    assert rules_engine_result.summary_output.maximum_heat_load == approx(
         data.summary.maximum_heat_load, abs=1
     )


### PR DESCRIPTION
Updated NormalizedBillingPeriodRecord to derive from BaseModel
Updated RulesEngineResult to derive from BaseModel
Updated various places where we had neglected to change inclusion_override to analysis_type_override
Added indirection from RulesEngineResult to SummaryOutput in test_engine.py
Fixed positional argument errors BillingPeriod test env setup