### PR TITLE
Linked Heat Stack and Rules Engine README.md's in main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ This team will determine the best way to allow users to store their past cases w
 ### Installation
 
 To install the front end, see this [README.md](https://github.com/codeforboston/home-energy-analysis-tool/blob/main/heat-stack/README.md)
+
+### Documentation
+For the Heat Stack (Javascript) portion read: [README.md](https://github.com/codeforboston/home-energy-analysis-tool/blob/main/heat-stack/README.md)
+For the Rules Engine (Python) portion read: [README.md](https://github.com/codeforboston/home-energy-analysis-tool/blob/main/rules-engine/README.md)


### PR DESCRIPTION
This change will let readers see the whole README.md tree from the main README.md to close #151.