### PR TITLE
Fix typescript misc

### DIFF
--- a/heat-stack/app/utils/misc.tsx
+++ b/heat-stack/app/utils/misc.tsx
@@ -272,7 +272,7 @@ export function useDebounce<
 	)
 }
 
-export async function downloadFile(url: string, retries: number = 0) {
+export async function downloadFile(url: string, retries: number = 0): Promise<any> {
 	const MAX_RETRIES = 3
 	try {
 		const response = await fetch(url)

--- a/heat-stack/temp.txt
+++ b/heat-stack/temp.txt
@@ -1,0 +1,1 @@
+Here I am

--- a/heat-stack/temp.txt
+++ b/heat-stack/temp.txt
@@ -1,1 +1,0 @@
-Here I am


### PR DESCRIPTION
I fixed misc.tsx so that it does not error when you run tsc.  I don't know why previous jobs were succeeding, but with one small change tsc works more consistently.  This is the error:
app/utils/misc.tsx:275:23 - error TS7023: 'downloadFile' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.

275 export async function downloadFile(url: string, retries: number = 0) {
                          ~~~~~~~~~~~~

