### PR TITLE
Switch to multiple devcontainer files

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,0 @@
-{
-  "image": "mcr.microsoft.com/devcontainers/universal:2",
-  "features": {
-    "ghcr.io/devcontainers/features/python:1": {
-        "version": "3.11.3"
-    }
-  }
-}

--- a/.devcontainer/heat-stack/devcontainer.json
+++ b/.devcontainer/heat-stack/devcontainer.json
@@ -1,0 +1,3 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/universal:2"
+}

--- a/.devcontainer/rules-engine/devcontainer.json
+++ b/.devcontainer/rules-engine/devcontainer.json
@@ -1,0 +1,3 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/python:3.11"
+}


### PR DESCRIPTION
In #183, we added a `devcontainer.json` file to customize the container used in GitHub Codespaces.  This was necessary because the default container is on Python 3.10, but the rules engine makes use of Python 3.11.

However, this had an unintended side-effect: the container takes ~4 minutes to build when a new one is created.  This PR changes the devcontainer files in the repository such that there are multiple images instead, one for the rules engine and one for the heat stack front-end.