### PR TITLE
Add instruction to install Git Large File Storage

### DIFF
--- a/heat-stack/README.md
+++ b/heat-stack/README.md
@@ -3,7 +3,8 @@
 ### On your computer
 
 ```
-# [install Git Large File Storage](https://git-lfs.com/)
+# install Git Large File Storage 
+docs here: https://git-lfs.com/
 Homebrew: brew install git-lfs
 run the command: git lfs install
 ```

--- a/heat-stack/README.md
+++ b/heat-stack/README.md
@@ -3,6 +3,12 @@
 ### On your computer
 
 ```
+# [install Git Large File Storage](https://git-lfs.com/)
+Homebrew: brew install git-lfs
+run the command: git lfs install
+```
+
+```
 git clone git@github.com:codeforboston/home-energy-analysis-tool.git
 # create an environment file
 cd heat-stack


### PR DESCRIPTION
Added instructions to the frontend README for installing [Git Large File Storage](https://git-lfs.com/), a step that should be completed before cloning the Home Energy Analysis Tool repo. Cloning the repo without installing `git-lfs` results in git only partially cloning the repo.