### PR TITLE
Enabled parsing of Eversource natural gas bills.

### DIFF
--- a/heat-stack/app/utils/rules-engine.ts
+++ b/heat-stack/app/utils/rules-engine.ts
@@ -82,7 +82,7 @@ export const executeParseGasBillPy: ExecuteParseFunction = await pyodide.runPyth
     from rules_engine import engine
 
     def executeParse(csvDataJs):
-        naturalGasInputRecords = parser.parse_gas_bill(csvDataJs, parser.NaturalGasCompany.NATIONAL_GRID)
+        naturalGasInputRecords = parser.parse_gas_bill(csvDataJs)
         return naturalGasInputRecords.model_dump(mode="json")
     executeParse
 `);
@@ -113,7 +113,7 @@ export const executeGetAnalyticsFromFormJs: ExecuteGetAnalyticsFunction = await 
         temperatureInputFromJs =temperatureInputJs.as_object_map().values()._mapping
 
         # We will just pass in this data
-        naturalGasInputRecords = parser.parse_gas_bill(csvDataJs, parser.NaturalGasCompany.NATIONAL_GRID)
+        naturalGasInputRecords = parser.parse_gas_bill(csvDataJs)
 
         design_temp_looked_up = helpers.get_design_temp(state_id, county_id)
         summaryInput = HeatLoadInput( **summaryInputFromJs, design_temperature=design_temp_looked_up)

--- a/python/src/rules_engine/parser.py
+++ b/python/src/rules_engine/parser.py
@@ -72,6 +72,23 @@ class _GasBillRowNationalGrid:
         self.usage = row["USAGE"]
 
 
+def _newline_line_ending(data: str) -> str:
+    """
+    Returns a csv with every line ending in a single newline
+    character.
+
+    Each Bill CSVs row ends variously, in a newline, carriage
+    return, and even a carriage return followed by a newline.
+    The company detection and parsing code crash unless each
+    row ends in one newline and nothing else.
+    """
+    data = data.replace("\r", "\n")
+    # replaces any number of consecutive newlines with one newline
+    regex = re.compile(r"\n+")
+    data = re.sub(regex, "\n", data)
+    return data
+
+
 def _detect_gas_company(data: str) -> NaturalGasCompany:
     """
     Return which natural gas company issued this bill.
@@ -96,6 +113,8 @@ def parse_gas_bill(
     Tries to automatically detect the company that sent the bill.
     Otherwise, requires the company be passed as an argument.
     """
+    data = _newline_line_ending(data)
+
     if company == None:
         company = _detect_gas_company(data)
 


### PR DESCRIPTION
- Added a private preprocessing function that replaces all line endings with a newline
- Run that function at the beginning of parse_gas_bill

Closes #303 