### PR TITLE
Remove unneeded descriptive text below Setback Hours Per Day input

### DIFF
--- a/heat-stack/app/components/ui/heat/CaseSummaryComponents/CurrentHeatingSystem.tsx
+++ b/heat-stack/app/components/ui/heat/CaseSummaryComponents/CurrentHeatingSystem.tsx
@@ -161,9 +161,6 @@ export function CurrentHeatingSystem(props: CurrentHeatingSystemProps) {
 						</Label>
 						<Input placeholder="(Optional)" {...getInputProps(props.fields.setback_hours_per_day, { type: "text" })} />
 						<div className={`${descriptiveClass}`}>
-							Typical natural gas efficiency is 80%-95%
-						</div>
-						<div className={`${descriptiveClass}`}>
 							Average hours per day that a lower or higher temperature setting
 							is in effect
 						</div>


### PR DESCRIPTION
Completes task within https://github.com/codeforboston/home-energy-analysis-tool/issues/322: "In the label below the Setback hours per day field, remove the line that says Typical natural gas efficiency is 80%-95%."