### PR TITLE
Update name and address labels

### DIFF
--- a/heat-stack/app/components/ui/heat/CaseSummaryComponents/HomeInformation.tsx
+++ b/heat-stack/app/components/ui/heat/CaseSummaryComponents/HomeInformation.tsx
@@ -56,11 +56,14 @@ export function HomeInformation(props: HomeInformationProps) {
 
 			{/* <Form method="post" action="/inputs1"> */}
 				<div className={`${componentMargin}`}>
-					<h6 className={`${subtitleClass}`}>Resident/Client</h6>
+					<h6>
+						<Label className={`${subtitleClass}`} htmlFor="name">
+							Resident/Client Name(s)
+						</Label>
+					</h6>
 
 					<div className="mt-4 flex space-x-4">
 						<div>
-							<Label htmlFor="name">Name</Label>
 							<Input {...getInputProps(props.fields.name, { type: "text" })} />
 							<div className="min-h-[32px] px-4 pb-3 pt-1">
 							<ErrorList
@@ -73,11 +76,14 @@ export function HomeInformation(props: HomeInformationProps) {
 				</div>
 
 				<div className="mt-9">
-					<h6 className={`${subtitleClass}`}>Address</h6>
+					<h6>
+						<Label className={`${subtitleClass}`} htmlFor="address">
+							Street Address, City, State
+						</Label>
+					</h6>
 
 					<div className="mt-4 flex space-x-4">
 						<div>
-							<Label htmlFor="address">Address</Label>
 							<Input {...getInputProps(props.fields.address, { type: "text" })} />
 							<div className="min-h-[32px] px-4 pb-3 pt-1">
 							<ErrorList


### PR DESCRIPTION
Completes tasks within https://github.com/codeforboston/home-energy-analysis-tool/issues/322:
- "For the *Resident/*Client field, change the label to Resident/Client Name(s). Remove the Name label that appears below that in a smaller-size font."
- "For the Address field, the label Address appears twice, first in a larger-size font and again in a smaller-size font. Change the first occurrence from Address to Street Address, City, State. Remove the second Address label that appears below in smaller-size font."