### PR TITLE
Increase retry count

### DIFF
--- a/heat-stack/app/utils/WeatherUtil.ts
+++ b/heat-stack/app/utils/WeatherUtil.ts
@@ -59,7 +59,7 @@ class WeatherUtil {
         params.append("temperature_unit","fahrenheit");
 
         let url = new URL(BASE_URL+WHATEVER_PATH+"?"+params.toString());
-        const maxRetries = 3;
+        const maxRetries = 10;
         let retryCount = 0;
         
         while (retryCount <= maxRetries) {

--- a/heat-stack/app/utils/WeatherUtil.ts
+++ b/heat-stack/app/utils/WeatherUtil.ts
@@ -59,7 +59,7 @@ class WeatherUtil {
         params.append("temperature_unit","fahrenheit");
 
         let url = new URL(BASE_URL+WHATEVER_PATH+"?"+params.toString());
-        const maxRetries = 10;
+        const maxRetries = 30;
         let retryCount = 0;
         
         while (retryCount <= maxRetries) {
@@ -87,7 +87,7 @@ class WeatherUtil {
             
             if (retryCount <= maxRetries) {
               // Exponential backoff
-              const delay = Math.pow(2, retryCount) * 1000; // 2s, 4s, 8s
+              const delay = 100;
               console.log(`Attempt ${retryCount} failed. Retrying in ${delay}ms...`);
               await new Promise(resolve => setTimeout(resolve, delay));
             } else {


### PR DESCRIPTION
We increased the retry count to thirty and decreased the waiting time between requests to a tenth of a second.  We believe that many fast retries may be better than a few spaced over many seconds.  This change may fix the frequent failure caused by the unavailablity of the weather API.