### PR TITLE
Fuel type fills automatically and lets form submit.

### DIFF
--- a/heat-stack/app/components/ui/heat/CaseSummaryComponents/CurrentHeatingSystem.tsx
+++ b/heat-stack/app/components/ui/heat/CaseSummaryComponents/CurrentHeatingSystem.tsx
@@ -55,7 +55,7 @@ export function CurrentHeatingSystem(props: CurrentHeatingSystemProps) {
 				</Label>
 				<div className="mt-4 flex space-x-4">
 					<div className="basis-1/4">
-						<Input aria-disabled={true} disabled={true} {...getInputProps(props.fields.fuel_type, { type: "text" })} />
+						<Input {...getInputProps(props.fields.fuel_type, { type: "text" })} />
 					</div>
 				</div>
 				<div className="min-h-[32px] px-4 pb-3 pt-1">


### PR DESCRIPTION
We removed `aria-disabled={true} disabled={true}` from line 58 of `[CurrentHeatingSystem.tsx](https://github.com/codeforboston/home-energy-analysis-tool/compare/bugfix/348/automatically-fill-fuel-type?expand=1#diff-116062c30648a401dc8724142c435f1da3b8a54302af793f5981295e3ea9b477)` to fix this bug.  We know that the arias are there for accessibility and need a way for the page to remain accessible, so we welcome feedback that will let the page both work and be accessible.