### PR TITLE
Handle errors to display at bottom

### DIFF
--- a/heat-stack/app/routes/_auth+/logout.tsx
+++ b/heat-stack/app/routes/_auth+/logout.tsx
@@ -1,11 +1,11 @@
-import { redirect } from 'react-router'
 import { logout } from '#app/utils/auth.server.ts'
 import { type Route } from './+types/logout.ts'
 
-export async function loader() {
-	return redirect('/')
+export const loader = async ({ request }: Route.LoaderArgs) => {
+	return logout({ request })
 }
 
-export async function action({ request }: Route.ActionArgs) {
+// Optional: remove action if you're not using a POST logout anywhere
+export const action = async ({ request }: Route.ActionArgs) => {
 	return logout({ request })
 }

--- a/heat-stack/app/routes/_heat+/single.tsx
+++ b/heat-stack/app/routes/_heat+/single.tsx
@@ -1,5 +1,5 @@
 //heat-stack/app/routes/_heat+/single.tsx
-import { SubmissionResult, useForm } from '@conform-to/react'
+import { type SubmissionResult, useForm } from '@conform-to/react'
 import { parseWithZod } from '@conform-to/zod'
 import { parseMultipartFormData } from '@remix-run/server-runtime/dist/formData.js'
 import React, { useState } from 'react'
@@ -45,8 +45,6 @@ import { HeatLoadAnalysis } from '../../components/ui/heat/CaseSummaryComponents
 import { HomeInformation } from '../../components/ui/heat/CaseSummaryComponents/HomeInformation.tsx'
 
 import { type Route } from './+types/single.ts'
-import { last } from 'lodash'
-
 
 /** TODO: Use url param "dev" to set defaults */
 

--- a/heat-stack/app/routes/_heat+/single.tsx
+++ b/heat-stack/app/routes/_heat+/single.tsx
@@ -304,7 +304,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 				);
 			} else {
 			return data(
-				// see comment for first submission.reply for additional options
+					// see comment for first submission.reply for additional options
 					submission.reply({
 					formErrors: ['Unknown Error'],
 				}),

--- a/heat-stack/app/routes/_heat+/single.tsx
+++ b/heat-stack/app/routes/_heat+/single.tsx
@@ -99,6 +99,17 @@ export async function action({ request, params }: Route.ActionArgs) {
 			console.error('submission failed', submission)
 		}
 		return submission.reply()
+		// submission.reply({
+		// 	// You can also pass additional error to the `reply` method
+		// 	formErrors: ['Submission failed'],
+		// 	fieldErrors: {
+		// 		address: ['Address is invalid'],
+		// 	},
+
+		// 	// or avoid sending the the field value back to client by specifying the field names
+		// 	hideFields: ['password'],
+		// }),
+		// {status: submission.status === "error" ? 400 : 200}
 	}
 
 	const {
@@ -285,6 +296,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 				const errorLines = error.message.split("\n").filter(Boolean)
 				const lastLine =  errorLines[errorLines.length-1] || error.message
 				return data(
+					// see comment for first submission.reply for additional options
 					submission.reply({
 						formErrors: [lastLine],
 					}),
@@ -292,7 +304,8 @@ export async function action({ request, params }: Route.ActionArgs) {
 				);
 			} else {
 			return data(
-				submission.reply({
+				// see comment for first submission.reply for additional options
+					submission.reply({
 					formErrors: ['Unknown Error'],
 				}),
 				{ status: 500 }

--- a/heat-stack/app/routes/_heat+/single.tsx
+++ b/heat-stack/app/routes/_heat+/single.tsx
@@ -365,8 +365,6 @@ export default function SubmitAnalysis({
 		shouldValidate: 'onBlur',
 		shouldRevalidate: 'onInput',
 	})
-	console.log("result", lastResult)
-	console.log("form.errors", form.errors)
 
 
 	return (

--- a/heat-stack/app/routes/_heat+/single.tsx
+++ b/heat-stack/app/routes/_heat+/single.tsx
@@ -289,28 +289,28 @@ export async function action({ request, params }: Route.ActionArgs) {
 			}
 		}
 	} 
-		catch (error: unknown) {
-			console.error("Calculate failed")
-			if (error instanceof Error) {
-				console.error(error.message)
-				const errorLines = error.message.split("\n").filter(Boolean)
-				const lastLine =  errorLines[errorLines.length-1] || error.message
-				return data(
-					// see comment for first submission.reply for additional options
-					submission.reply({
-						formErrors: [lastLine],
-					}),
-					{ status: 500 }
-				);
-			} else {
+	catch (error: unknown) {
+		console.error("Calculate failed")
+		if (error instanceof Error) {
+			console.error(error.message)
+			const errorLines = error.message.split("\n").filter(Boolean)
+			const lastLine =  errorLines[errorLines.length-1] || error.message
 			return data(
-					// see comment for first submission.reply for additional options
-					submission.reply({
-					formErrors: ['Unknown Error'],
+				// see comment for first submission.reply for additional options
+				submission.reply({
+					formErrors: [lastLine],
 				}),
 				{ status: 500 }
 			);
-		}
+		} else {
+		return data(
+				// see comment for first submission.reply for additional options
+				submission.reply({
+				formErrors: ['Unknown Error'],
+			}),
+			{ status: 500 }
+		);
+	}
 	}
 	// return redirect(`/single`)
 } //END OF action

--- a/heat-stack/app/routes/_heat+/single.tsx
+++ b/heat-stack/app/routes/_heat+/single.tsx
@@ -1,9 +1,9 @@
 //heat-stack/app/routes/_heat+/single.tsx
-import { useForm } from '@conform-to/react'
+import { SubmissionResult, useForm } from '@conform-to/react'
 import { parseWithZod } from '@conform-to/zod'
 import { parseMultipartFormData } from '@remix-run/server-runtime/dist/formData.js'
 import React, { useState } from 'react'
-import { Form } from 'react-router'
+import { Form, data } from 'react-router'
 import { type z } from 'zod'
 import { EnergyUseHistoryChart } from '#app/components/ui/heat/CaseSummaryComponents/EnergyUseHistoryChart.tsx'
 import { ErrorList } from '#app/components/ui/heat/CaseSummaryComponents/ErrorList.tsx'
@@ -45,6 +45,7 @@ import { HeatLoadAnalysis } from '../../components/ui/heat/CaseSummaryComponents
 import { HomeInformation } from '../../components/ui/heat/CaseSummaryComponents/HomeInformation.tsx'
 
 import { type Route } from './+types/single.ts'
+import { last } from 'lodash'
 
 
 /** TODO: Use url param "dev" to set defaults */
@@ -76,10 +77,6 @@ export async function loader({ request }: Route.LoaderArgs) {
 	return { isDevMode }
 }
 
-interface ErrorWithExceptionMessage extends Error {
-	exceptionMessage?: string;
-}
-
 /* consolidate into FEATUREFLAG_PRISMA_HEAT_BETA2 when extracted into sep. file, export it */
 export interface CaseInfo {
 	caseId?: number;
@@ -87,6 +84,7 @@ export interface CaseInfo {
 	heatingInputId?: number;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export async function action({ request, params }: Route.ActionArgs) {
 	// Checks if url has a homeId parameter, throws 400 if not there
 	// invariantResponse(params.homeId, 'homeId param is required')
@@ -103,17 +101,6 @@ export async function action({ request, params }: Route.ActionArgs) {
 			console.error('submission failed', submission)
 		}
 		return submission.reply()
-		// submission.reply({
-		// 	// You can also pass additional error to the `reply` method
-		// 	formErrors: ['Submission failed'],
-		// 	fieldErrors: {
-		// 		address: ['Address is invalid'],
-		// 	},
-
-		// 	// or avoid sending the the field value back to client by specifying the field names
-		// 	hideFields: ['password'],
-		// }),
-		// {status: submission.status === "error" ? 400 : 200}
 	}
 
 	const {
@@ -155,279 +142,235 @@ export async function action({ request, params }: Route.ActionArgs) {
 		// design_temperature: 12 /* TODO:  see #162 and esp. #123*/
 	})
 
-	// This assignment of the same name is a special thing. We don't remember the name right now.
-	// It's not necessary, but it is possible.
-	const pyodideResultsFromTextFilePyProxy: PyProxy =
-		executeParseGasBillPy(uploadedTextFile)
-	const pyodideResultsFromTextFile: NaturalGasUsageDataSchema =
-		executeParseGasBillPy(uploadedTextFile).toJs()
-	pyodideResultsFromTextFilePyProxy.destroy()
-
-	/** This function takes a CSV string and an address
-	 * and returns date and weather data,
-	 * and geolocation information
-	 */
-
-	let convertedDatesTIWD, state_id, county_id
-	// Define variables at function scope for access in the return statement
-	let caseRecord, analysis, heatingInput
 	try {
-		const result = await getConvertedDatesTIWD(
-			pyodideResultsFromTextFile,
-			street_address,
-			town,
-			state
+		// This assignment of the same name is a special thing. We don't remember the name right now.
+		// It's not necessary, but it is possible.
+		const pyodideResultsFromTextFilePyProxy: PyProxy =
+			executeParseGasBillPy(uploadedTextFile)
+		const pyodideResultsFromTextFile: NaturalGasUsageDataSchema =
+			executeParseGasBillPy(uploadedTextFile).toJs()
+		pyodideResultsFromTextFilePyProxy.destroy()
+
+		/** This function takes a CSV string and an address
+		 * and returns date and weather data,
+		 * and geolocation information
+		 */
+
+		let convertedDatesTIWD, state_id, county_id
+		// Define variables at function scope for access in the return statement
+		let caseRecord, analysis, heatingInput
+			const result = await getConvertedDatesTIWD(
+				pyodideResultsFromTextFile,
+				street_address,
+				town,
+				state
+			)
+			convertedDatesTIWD = result.convertedDatesTIWD
+			state_id = result.state_id
+			county_id = result.county_id
+
+			if (process.env.FEATUREFLAG_PRISMA_HEAT_BETA2 === "true") {
+				/* TODO: refactor out into a separate file. 
+						for args, use submission.values, result
+				*/
+				// Save to database using Prisma
+				// First create or find HomeOwner
+				const homeOwner = await prisma.homeOwner.create({
+					data: {
+						firstName1: name.split(' ')[0] || 'Unknown',
+						lastName1: name.split(' ').slice(1).join(' ') || 'Owner',
+						email1: '', // We'll need to add these to the form
+						firstName2: '',
+						lastName2: '',
+						email2: '',
+					},
+				})
+
+				// Create location using geocoded information
+				const location = await prisma.location.create({
+					data: {
+						address: result.addressComponents?.street || street_address,
+						city: result.addressComponents?.city || town,
+						state: result.addressComponents?.state || state,
+						zipcode: result.addressComponents?.zip || '',
+						country: 'USA',
+						livingAreaSquareFeet: Math.round(living_area),
+						latitude: result.coordinates?.y || 0,
+						longitude: result.coordinates?.x || 0,
+					},
+				})
+
+				// Create Case
+				caseRecord = await prisma.case.create({
+					data: {
+						homeOwnerId: homeOwner.id,
+						locationId: location.id,
+					},
+				})
+
+				// Create Analysis
+				analysis = await prisma.analysis.create({
+					data: {
+						caseId: caseRecord.id,
+						rules_engine_version: '0.0.1',
+					},
+				})
+
+				// Create HeatingInput
+				heatingInput = await prisma.heatingInput.create({
+					data: {
+						analysisId: analysis.id,
+						fuelType: fuel_type,
+						designTemperatureOverride: Boolean(design_temperature_override),
+						heatingSystemEfficiency: Math.round(heating_system_efficiency * 100),
+						thermostatSetPoint: thermostat_set_point,
+						setbackTemperature: setback_temperature || 65,
+						setbackHoursPerDay: setback_hours_per_day || 0,
+						numberOfOccupants: 2, // Default value until we add to form
+						estimatedWaterHeatingEfficiency: 80, // Default value until we add to form
+						standByLosses: 5, // Default value until we add to form
+						livingArea: living_area,
+					},
+				})
+
+				/* TODO: store uploadedTextFile CSV/XML raw into AnalysisDataFile table */
+
+				/* TODO: store rules-engine output in database too */
+			}
+			
+
+		// } catch (error) {
+		// 	const errorWithExceptionMessage = error as ErrorWithExceptionMessage
+		// 	if (errorWithExceptionMessage && errorWithExceptionMessage.exceptionMessage) {
+		// 		return { exceptionMessage: errorWithExceptionMessage.exceptionMessage }
+		// 	}
+		// 	throw error
+		// }
+
+		/** Main form entrypoint
+		 */
+
+		// Call to the rules-engine with raw text file
+		const gasBillDataFromTextFilePyProxy: PyProxy = executeGetAnalyticsFromFormJs(
+			parsedAndValidatedFormSchema,
+			convertedDatesTIWD,
+			uploadedTextFile,
+			state_id,
+			county_id,
 		)
-		convertedDatesTIWD = result.convertedDatesTIWD
-		state_id = result.state_id
-		county_id = result.county_id
+		const gasBillDataFromTextFile = gasBillDataFromTextFilePyProxy.toJs()
+		gasBillDataFromTextFilePyProxy.destroy()
 
-		if (process.env.FEATUREFLAG_PRISMA_HEAT_BETA2 === "true") {
-			/* TODO: refactor out into a separate file. 
-					for args, use submission.values, result
-			*/
-			// Save to database using Prisma
-			// First create or find HomeOwner
-			const homeOwner = await prisma.homeOwner.create({
-				data: {
-					firstName1: name.split(' ')[0] || 'Unknown',
-					lastName1: name.split(' ').slice(1).join(' ') || 'Owner',
-					email1: '', // We'll need to add these to the form
-					firstName2: '',
-					lastName2: '',
-					email2: '',
-				},
-			})
+		// Call to the rules-engine with adjusted data (see checkbox implementation in recalculateFromBillingRecordsChange)
+		// const calculatedData: any = executeRoundtripAnalyticsFromFormJs(parsedAndValidatedFormSchema, convertedDatesTIWD, gasBillDataFromTextFile, state_id, county_id).toJs()
 
-			// Create location using geocoded information
-			const location = await prisma.location.create({
-				data: {
-					address: result.addressComponents?.street || street_address,
-					city: result.addressComponents?.city || town,
-					state: result.addressComponents?.state || state,
-					zipcode: result.addressComponents?.zip || '',
-					country: 'USA',
-					livingAreaSquareFeet: Math.round(living_area),
-					latitude: result.coordinates?.y || 0,
-					longitude: result.coordinates?.x || 0,
-				},
-			})
+		const str_version = JSON.stringify(gasBillDataFromTextFile, replacer)
 
-			// Create Case
-			caseRecord = await prisma.case.create({
-				data: {
-					homeOwnerId: homeOwner.id,
-					locationId: location.id,
-				},
-			})
-
-			// Create Analysis
-			analysis = await prisma.analysis.create({
-				data: {
-					caseId: caseRecord.id,
-					rules_engine_version: '0.0.1',
-				},
-			})
-
-			// Create HeatingInput
-			heatingInput = await prisma.heatingInput.create({
-				data: {
-					analysisId: analysis.id,
-					fuelType: fuel_type,
-					designTemperatureOverride: Boolean(design_temperature_override),
-					heatingSystemEfficiency: Math.round(heating_system_efficiency * 100),
-					thermostatSetPoint: thermostat_set_point,
-					setbackTemperature: setback_temperature || 65,
-					setbackHoursPerDay: setback_hours_per_day || 0,
-					numberOfOccupants: 2, // Default value until we add to form
-					estimatedWaterHeatingEfficiency: 80, // Default value until we add to form
-					standByLosses: 5, // Default value until we add to form
-					livingArea: living_area,
-				},
-			})
-
-			/* TODO: store uploadedTextFile CSV/XML raw into AnalysisDataFile table */
-
-			/* TODO: store rules-engine output in database too */
+		return {
+			data: str_version,
+			parsedAndValidatedFormSchema,
+			convertedDatesTIWD,
+			state_id,
+			county_id,
+			// Return case information for linking to case details
+			caseInfo: {
+				caseId: caseRecord?.id,
+				analysisId: analysis?.id,
+				heatingInputId: heatingInput?.id
+			}
 		}
-
-	} catch (error) {
-		const errorWithExceptionMessage = error as ErrorWithExceptionMessage
-		if (errorWithExceptionMessage && errorWithExceptionMessage.exceptionMessage) {
-			return { exceptionMessage: errorWithExceptionMessage.exceptionMessage }
-		}
-		throw error
-	}
-
-	/** Main form entrypoint
-	 */
-
-	// Call to the rules-engine with raw text file
-	const gasBillDataFromTextFilePyProxy: PyProxy = executeGetAnalyticsFromFormJs(
-		parsedAndValidatedFormSchema,
-		convertedDatesTIWD,
-		uploadedTextFile,
-		state_id,
-		county_id,
-	)
-	const gasBillDataFromTextFile = gasBillDataFromTextFilePyProxy.toJs()
-	gasBillDataFromTextFilePyProxy.destroy()
-
-	console.log(
-		'***** Rules-engine Output from CSV upload:',
-		gasBillDataFromTextFile,
-	)
-
-	// Call to the rules-engine with adjusted data (see checkbox implementation in recalculateFromBillingRecordsChange)
-	// const calculatedData: any = executeRoundtripAnalyticsFromFormJs(parsedAndValidatedFormSchema, convertedDatesTIWD, gasBillDataFromTextFile, state_id, county_id).toJs()
-
-	const str_version = JSON.stringify(gasBillDataFromTextFile, replacer)
-
-	return {
-		data: str_version,
-		parsedAndValidatedFormSchema,
-		convertedDatesTIWD,
-		state_id,
-		county_id,
-		// Return case information for linking to case details
-		caseInfo: {
-			caseId: caseRecord?.id,
-			analysisId: analysis?.id,
-			heatingInputId: heatingInput?.id
+	} 
+		catch (error: unknown) {
+			console.error("Calculate failed")
+			if (error instanceof Error) {
+				console.error(error.message)
+				const errorLines = error.message.split("\n").filter(Boolean)
+				const lastLine =  errorLines[errorLines.length-1] || error.message
+				return data(
+					submission.reply({
+						formErrors: [lastLine],
+					}),
+					{ status: 500 }
+				);
+			} else {
+			return data(
+				submission.reply({
+					formErrors: ['Unknown Error'],
+				}),
+				{ status: 500 }
+			);
 		}
 	}
 	// return redirect(`/single`)
 } //END OF action
 
+
 export default function SubmitAnalysis({
 	loaderData,
 	actionData,
 }: Route.ComponentProps) {
-	// USAGE OF lastResult
-	// console.log("lastResult (all Rules Engine data)", lastResult !== undefined ? JSON.parse(lastResult.data, reviver): undefined)
-
-	/**
-	 * Example Data Returned
-	 * Where temp1 is a temporary variable with the main Map of Maps (or undefined if page not yet submitted).
-	 * 
-	 * 1 of 3: heat_load_output
-	 * console.log("Summary Output", lastResult !== undefined ? JSON.parse(lastResult.data, reviver)?.get('heat_load_output'): undefined)
-	 * 
-	 * temp1.get('heat_load_output'): Map(9) { 
-		* estimated_balance_point → 61.5, 
-		* other_fuel_usage → 0.2857142857142857, 
-		* average_indoor_temperature → 67, 
-		* difference_between_ti_and_tbp → 5.5, 
-		* design_temperature → 1, 
-		* whole_home_heat_loss_rate → 48001.81184312083, 
-		* standard_deviation_of_heat_loss_rate → 0.08066745182677547, 
-		* average_heat_load → 3048115.0520381727, 
-		* maximum_heat_load → 3312125.0171753373 
-	 * }
-	 * 
-	 * 
-	 * 2 of 3: processed_energy_bills
-	 * console.log("EnergyUseHistoryChart table data", lastResult !== undefined ? JSON.parse(lastResult.data, reviver)?.get('processed_energy_bills'): undefined)
-	 *
-	 * temp1.get('processed_energy_bills')
-	 * Array(25) [ Map(9), Map(9), Map(9), Map(9), Map(9), Map(9), Map(9), Map(9), Map(9), Map(9), … ]
-	 * 
-	 * temp1.get('processed_energy_bills')[0]
-	 * Map(9) { period_start_date → "2020-10-02", period_end_date → "2020-11-04", usage → 29, analysis_type_override → null, inclusion_override → true, analysis_type → 0, default_inclusion → false, eliminated_as_outlier → false, whole_home_heat_loss_rate → null }
-	 * 
-	 * temp1.get('processed_energy_bills')[0].get('period_start_date')
-	 * "2020-10-02" 
-	 * 
-	 * 
-	 * 3 of 3: balance_point_graph
-	 * console.log("HeatLoad chart", lastResult !== undefined ? JSON.parse(lastResult.data, reviver)?.get('balance_point_graph')?.get('records'): undefined) 
-	 * 
-	 * temp1.get('balance_point_graph').get('records')
-		Array(23) [ Map(5), Map(5), Map(5), Map(5), Map(5), Map(5), Map(5), Map(5), Map(5), Map(5), … ]
-		temp1.get('balance_point_graph').get('records')[0]
-		Map(5) { balance_point → 60, heat_loss_rate → 51056.8007761249, change_in_heat_loss_rate → 0, percent_change_in_heat_loss_rate → 0, standard_deviation → 0.17628334816871494 }
-		temp1.get('balance_point_graph').get('records')[0].get('heat_loss_rate') 
-	 */
 	const [usageData, setUsageData] = useState<UsageDataSchema | undefined>()
-	const [tally, setTally] = useState(0)
-	// const [lastResult, setLastResult] = useState<(typeof actionData & { caseInfo?: CaseInfo }) | undefined>()
 	const [scrollAfterSubmit, setScrollAfterSubmit] = useState(false)
 	const [savedCase, setSavedCase] = useState<CaseInfo | undefined>()
-	const {lazyLoadRulesEngine, recalculateFromBillingRecordsChange} = useRulesEngine()
+	const { lazyLoadRulesEngine, recalculateFromBillingRecordsChange } = useRulesEngine()
+
+	// ✅ Extract structured values from actionData
+	const lastResult = actionData // The actual submission result
+	const caseInfo = (actionData as typeof actionData & { caseInfo?: CaseInfo })?.caseInfo
 
 	React.useEffect(() => {
-		// Set case info if available
-		// Type assertion to handle the extended actionData type
-		const typedActionData = actionData as typeof actionData & { caseInfo?: CaseInfo };
-		if (typedActionData?.caseInfo) {
-			setSavedCase(typedActionData.caseInfo)
+		if (caseInfo) {
+			setSavedCase(caseInfo)
 		}
-	}, [actionData])
-
-	const lastResult: (typeof actionData & { caseInfo?: CaseInfo }) | undefined = actionData
-	let showUsageData = lastResult !== undefined
+	}, [caseInfo])
 
 	let parsedLastResult: Map<any, any> | undefined
+	const showUsageData = lastResult !== undefined
 
 	if (showUsageData && hasDataProperty(lastResult)) {
-		// Parse the JSON string from lastResult.data
-		// const parsedLastResult = JSON.parse(lastResult.data, reviver) as Map<any, any>;
 		parsedLastResult = JSON.parse(lastResult.data, reviver) as Map<any, any>
-
-		const newUsageData =
-			parsedLastResult && buildCurrentUsageData(parsedLastResult)
-		if (tally < 4) {
-			setTally(tally + 1)
-			setUsageData((prevUsageData) => {
-				if (objectToString(prevUsageData) != objectToString(newUsageData)) {
-					return newUsageData
-				}
-				return prevUsageData
-			})
+		const newUsageData = buildCurrentUsageData(parsedLastResult)
+		if (objectToString(usageData) !== objectToString(newUsageData)) {
+			setUsageData(newUsageData)
 		}
 	}
 
 	type SchemaZodFromFormType = z.infer<typeof Schema>
+	type MinimalFormData = { fuel_type: 'GAS' }
 
-	type MinimalFormData = {
-		fuel_type: 'GAS',
-	}
 	const defaultValue: SchemaZodFromFormType | MinimalFormData | undefined =
 		loaderData.isDevMode
 			? {
 				living_area: 2155,
 				street_address: '15 Dale Ave',
 				town: 'Gloucester',
-				// Only the initial state value in the useState of HomeInformation.tsx matters.
 				state: 'MA',
 				name: 'CIC',
-				// Only the initial fuel_type value in the useState of CurrentHeatingSystem.tsx matters.
-				fuel_type: 'GAS',   
+				fuel_type: 'GAS',
 				heating_system_efficiency: 0.97,
 				thermostat_set_point: 68,
 				setback_temperature: 65,
 				setback_hours_per_day: 8,
-				// design_temperature_override: '',
 			}
 			: { fuel_type: 'GAS' }
 
+	// ✅ Pass `result` as `lastResult`
 	const [form, fields] = useForm({
-		/* removed lastResult , consider re-adding https://conform.guide/api/react/useForm#options */
-
+		lastResult: actionData as SubmissionResult<string[]>,
 		onValidate({ formData }) {
 			return parseWithZod(formData, { schema: Schema })
 		},
-		
-		onSubmit(){
+		onSubmit() {
 			lazyLoadRulesEngine()
 		},
-
 		defaultValue,
 		shouldValidate: 'onBlur',
-		shouldRevalidate: 'onInput'
+		shouldRevalidate: 'onInput',
 	})
+	console.log("result", lastResult)
+	console.log("form.errors", form.errors)
 
-	// @TODO: we might need to guarantee that Data exists before rendering - currently we need to typecast an empty object in order to pass typechecking for <EnergyUsHistory />
+
 	return (
 		<>
 			<Form
@@ -439,15 +382,11 @@ export default function SubmitAnalysis({
 				aria-invalid={form.errors ? true : undefined}
 				aria-describedby={form.errors ? form.errorId : undefined}
 			>
-				{' '}
-				{/* https://github.com/edmundhung/conform/discussions/547 instructions on how to properly set default values
-			This will make it work when JavaScript is turned off as well 
-			<Input {...getInputProps(props.fields.address, { type: "text" })} /> */}
 				<HomeInformation fields={fields} />
 				<CurrentHeatingSystem fields={fields} />
-				{/* if no usage data, show the file upload functionality */}
 				<EnergyUseUpload setScrollAfterSubmit={setScrollAfterSubmit} fields={fields} />
 				<ErrorList id={form.errorId} errors={form.errors} />
+
 				{showUsageData && usageData && recalculateFromBillingRecordsChange && (
 					<>
 						<AnalysisHeader
@@ -462,7 +401,7 @@ export default function SubmitAnalysis({
 							parsedLastResult={parsedLastResult}
 							recalculateFn={recalculateFromBillingRecordsChange}
 						/>
-						{/* Replace regular HeatLoadAnalysis with our debug wrapper */}
+
 						{usageData &&
 							usageData.heat_load_output &&
 							usageData.heat_load_output.design_temperature &&
@@ -477,7 +416,7 @@ export default function SubmitAnalysis({
 								<h2 className="mb-4 text-xl font-bold text-red-600">
 									Not rendering Heat Load
 								</h2>
-								<p>usageData is undefined or null</p>
+								<p>usageData is undefined or missing key values</p>
 							</div>
 						)}
 					</>
@@ -498,14 +437,7 @@ export default function SubmitAnalysis({
 					</p>
 				</div>
 			)}
-			{/* // TODO: This is good to display errors from Conform which accidentally haven't been explicitly shown anywhere else
-			 {Object.entries(form.allErrors ?? {}).map(([fieldName, errors]) => (
-				<ErrorList
-					key={fieldName}
-					id={`${form.id}-${fieldName}-error`}
-					errors={errors}
-				/>
-			))} */}
 		</>
 	)
 }
+


### PR DESCRIPTION
Closes #458

- modify logout.tsx so can log out and log in, which makes it possible to review error processing in log in
- single.tsx
  - add try catch around the code that executes python.  
  - in the catch, use submission.reply to return result, which then populates form.errors
  - existing code displays the form.errors
  
  Tests: 
  - upload and calculate a csv with one of the columns misnamed
  - upload and calculate a csv where one row uses letters instead of numbers
  - upload and calculate a csv that is correct