### PR TITLE
Use python 3.12

### DIFF
--- a/heat-stack/README.md
+++ b/heat-stack/README.md
@@ -98,23 +98,31 @@ for managing Node.js versions (nvm is preinstalled in coding spaces).
 
 ### Install Dependencies and Build
 
-1. Install project dependencies:
+1. Change directory to heat-stack
+   ```
+   cd heat-stack
+   ```
+2. Use Node.js version 22:
+   ```bash
+   nvm use 22
+   ```
+3. Install project dependencies:
    ```bash
    npm install
    ```
-2. Build the rules engine into the `public/pyodide-env` folder:
+4. Build the rules engine into the `public/pyodide-env` folder:
    ```bash
    npm run buildpy
    ```
-3. Copy the example environment file into a new `.env` file:
+5. Copy the example environment file into a new `.env` file:
    ```bash
    cp .env.example .env
    ```
-4. Setup the SQLite Database:
+6. Setup the SQLite Database:
    ```bash
    npm run setup
    ```
-5. Start the development server:
+7. Start the development server:
    ```bash
    npm run dev
    ```

--- a/python/setup-python.sh
+++ b/python/setup-python.sh
@@ -1,35 +1,45 @@
-
 #!/bin/bash
-# Call detect_python.sh and capture its echo output
-trap 'echo "An error occurred"; set +x' ERR
-set -x
 
-echo $PYTHON_CMD
-if [[ -z "$PYTHON_CMD" ]]; then
-  echo B
-  PYTHON_CMD=$(./get-python-cmd.sh)
-  if [[ -z "$PYTHON_CMD" ]]; then
-    echo "Error: No suitable Python 3 interpreter found."
-    return 1
-  fi
+# Trap errors and print a message
+trap 'echo "An error occurred"; set +x' ERR
+
+# Detect the operating system
+OS=$(uname)
+
+# Set the PYTHON_CMD environment variable based on the operating system
+if [[ "$OS" == "Linux" ]] || [[ "$OS" == "Darwin" ]]; then
+    # Set the PYTHON_CMD environment variable for Linux or macOS
+    export PYTHON_CMD="python3.12"
+elif [[ "$OS" == *"MINGW"* ]] || [[ "$OS" == *"CYGWIN"* ]]; then
+    # Set the PYTHON_CMD environment variable for Windows (using Git Bash or WSL)
+    export PYTHON_CMD="py -3.12"
+else
+    echo "Unsupported operating system: $OS"
+    exit 1
 fi
+
+# Print the PYTHON_CMD for verification
+echo "PYTHON_CMD is set to: $PYTHON_CMD"
 
 echo "Using Python command: $PYTHON_CMD"
 
-source check-version.sh || return 1
+# Source the check-version.sh script
+source check-version.sh || { echo "Error: check-version.sh failed"; exit 1; }
 
-# Your other python commands can use $PYTHON_CMD
-
+# Create a virtual environment
 $PYTHON_CMD -m venv venv
 
+# Activate the virtual environment
 case "$OSTYPE" in
   msys*) source venv/Scripts/activate;;
   *) source venv/bin/activate;;
 esac
 
+# Install dependencies
 pip install -e .
 pip install -r requirements-dev.txt
 pip install --upgrade pip
 pre-commit install
 
+# End of script
 set +x


### PR DESCRIPTION
We have modified the shell script to enforce using Python 3.12 and updated the README to mention using nvm 22 before installing.