### PR TITLE
Redirect from /cases to /login if needed

### DIFF
--- a/heat-stack/app/routes/cases+/index.tsx
+++ b/heat-stack/app/routes/cases+/index.tsx
@@ -1,8 +1,7 @@
-import { data, useLoaderData, Link } from 'react-router'
-import { format } from 'date-fns'
+import { data, Link } from 'react-router'
+import { requireUserId } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import { type Route } from './+types/index.ts'
-import { requireUserId } from '#app/utils/auth.server.ts'
 
 export async function loader({ request }: Route.LoaderArgs) {
     await requireUserId(request)

--- a/heat-stack/app/routes/cases+/index.tsx
+++ b/heat-stack/app/routes/cases+/index.tsx
@@ -2,10 +2,10 @@ import { data, useLoaderData, Link } from 'react-router'
 import { format } from 'date-fns'
 import { prisma } from '#app/utils/db.server.ts'
 import { type Route } from './+types/index.ts'
-import { getUserId } from '#app/utils/auth.server.ts'
+import { requireUserId } from '#app/utils/auth.server.ts'
 
 export async function loader({ request }: Route.LoaderArgs) {
-    const userID = getUserId(request)
+    await requireUserId(request)
     // Fetch all cases with their related data
     const cases = await prisma.case.findMany({
         include: {


### PR DESCRIPTION
If the user navigates to `/cases` without logging in, this will load the login page before viewing the cases.