### PR TITLE
fix: form to persist submit results to prevent fields from getting reset

### DIFF
--- a/heat-stack/app/routes/_heat+/single.tsx
+++ b/heat-stack/app/routes/_heat+/single.tsx
@@ -1,5 +1,5 @@
 //heat-stack/app/routes/_heat+/single.tsx
-import { type SubmissionResult, useForm } from '@conform-to/react'
+import { useForm } from '@conform-to/react'
 import { parseWithZod } from '@conform-to/zod'
 import { parseMultipartFormData } from '@remix-run/server-runtime/dist/formData.js'
 import React, { useState } from 'react'
@@ -98,7 +98,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 			// this can have personal identifying information, so only active in development.
 			console.error('submission failed', submission)
 		}
-		return submission.reply()
+		return {submitResult: submission.reply()}
 		// submission.reply({
 		// 	// You can also pass additional error to the `reply` method
 		// 	formErrors: ['Submission failed'],
@@ -276,6 +276,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 		const str_version = JSON.stringify(gasBillDataFromTextFile, replacer)
 
 		return {
+			submitResult:submission.reply(),
 			data: str_version,
 			parsedAndValidatedFormSchema,
 			convertedDatesTIWD,
@@ -297,17 +298,17 @@ export async function action({ request, params }: Route.ActionArgs) {
 			const lastLine = errorLines[errorLines.length - 1] || error.message
 			return data(
 				// see comment for first submission.reply for additional options
-				submission.reply({
+				{submitResult:submission.reply({
 					formErrors: [lastLine],
-				}),
+				})},
 				{ status: 500 }
 			);
 		} else {
 			return data(
 				// see comment for first submission.reply for additional options
-				submission.reply({
+				{submitResult:submission.reply({
 					formErrors: ['Unknown Error'],
-				}),
+				})},
 				{ status: 500 }
 			);
 		}
@@ -386,7 +387,7 @@ export default function SubmitAnalysis({
 
 	// ✅ Pass `result` as `lastResult`
 	const [form, fields] = useForm({
-		lastResult: actionData as SubmissionResult<string[]>,
+		lastResult: actionData?.submitResult,
 		onValidate({ formData }) {
 			return parseWithZod(formData, { schema: Schema })
 		},

--- a/heat-stack/app/utils/index.ts
+++ b/heat-stack/app/utils/index.ts
@@ -78,17 +78,19 @@ export const buildCurrentUsageData = (
 	return newUsageData
 }
 
-type ActionResult =
+export type ActionResult =
 	| (SubmissionResult<string[]> & { caseInfo?: CaseInfo })
-	| ({ data: string } & { caseInfo?: CaseInfo })
+	| ({ data: string } & { caseInfo?: CaseInfo } & { formResult?: SubmissionResult<string[]>  })
 	| undefined
 
 /** typeguard for useAction between string[] and {data: string} */
 export function hasDataProperty(
-	result: ActionResult,
+	result: unknown,
 ): result is { data: string } {
 	return (
 		result !== undefined &&
+		result !== null &&
+		typeof result === "object" && 
 		'data' in result &&
 		typeof (result as any).data === 'string'
 	)

--- a/heat-stack/tests/e2e/energy-analysis.test.ts
+++ b/heat-stack/tests/e2e/energy-analysis.test.ts
@@ -50,3 +50,49 @@ test('Logged out user can upload CSV, toggle table row checkbox, expecting analy
 	// expect not equal
 	expect(tableHeaderContentAfterClick).not.toEqual(tableHeaderContentBeforeClick);
 })
+
+test('Custom name persists after form submission', async ({ page }) => {
+	// Visit the root
+	await page.goto('/')
+
+	// click the "demo data" link
+	await page.getByText('Get Started (with Demo Data)').click()
+
+	// Get the name input field and verify it has the default value
+	let nameInput = page.locator('input[name="name"]')
+	await expect(nameInput).toHaveValue('CIC')
+
+	// Change the name to a custom value
+	const customName = 'John Smith'
+	await nameInput.fill(customName)
+	await expect(nameInput).toHaveValue(customName)
+
+	// Upload the CSV file
+	await page
+		.getByTestId('upload-billing')
+		.nth(0)
+		.setInputFiles(
+			'tests/fixtures/csv/green_button_gas_bill_quateman_for_test.csv',
+		)
+
+	// Submit the form by clicking the Calculate button
+	await page.locator('button[name="intent"][value="upload"]').click()
+
+	// Waits for the URL, continues as soon as the URL appears
+	// and times out if 15 seconds have passed without the URL appearing
+	await page.waitForURL('/single', { timeout: 15_000 })
+
+	const tableHeaderContent = await getAnalysisHeaderTextContent(page)
+
+	// sanity test to make sure page has updated
+	expect(tableHeaderContent).not.toBeNull()
+
+	// look up input field again to make sure we are working with a fresh copy of the element
+	nameInput = page.locator('input[name="name"]')
+
+	// Verify that the name field still contains the custom value after submission
+	await expect(nameInput).toHaveValue(customName)
+
+	// Also verify that the name field is not reset to the default value
+	await expect(nameInput).not.toHaveValue('CIC')
+})


### PR DESCRIPTION
PR to fix #557
### Changes
1. Fixed `lastResult` to get passed submission results from `parseWithZod` to persist form values across submits
2. Updated `action` to always return `{submitResult:  submission.reply()}` so that we can use the results to pass to `lastResult` to prevent form inputs from getting reset after a submit
3. Added test to make sure name input field persists across submit
4. Added additional checks in `hasDataProperty` and made type unknown to get around type errors

 