### PR TITLE
feat: add search functionality for cases by home owner and location

### DIFF
--- a/heat-stack/app/routes/cases+/$analysisid.tsx
+++ b/heat-stack/app/routes/cases+/$analysisid.tsx
@@ -53,9 +53,9 @@ export default function Analysis({
 			<h1 className="mb-6 text-3xl font-bold">Case Analysis #{caseData.id}</h1>
 
 			<div className="mb-8 grid grid-cols-1 gap-6 md:grid-cols-2">
-				{/* Home Owner Information */}
+				{/* Homeowner Information */}
 				<div className="rounded-lg border p-4 shadow-sm">
-					<h2 className="mb-4 text-xl font-semibold">Home Owner</h2>
+					<h2 className="mb-4 text-xl font-semibold">Homeowner</h2>
 					<p className="mb-2">
 						<span className="font-medium">Name:</span>{' '}
 						{caseData.homeOwner.firstName1} {caseData.homeOwner.lastName1}

--- a/heat-stack/app/routes/cases+/index.tsx
+++ b/heat-stack/app/routes/cases+/index.tsx
@@ -1,44 +1,70 @@
-import { data, Link } from 'react-router'
+import { Form, data, Link, useSubmit } from 'react-router'
+import { Icon } from '#app/components/ui/icon.tsx'
 import { requireUserId } from '#app/utils/auth.server.ts'
 import { getCasesByUser } from '#app/utils/db/case.server.ts'
 import { type Route } from './+types/index.ts'
 
 export async function loader({ request }: Route.LoaderArgs) {
 	const userId = await requireUserId(request)
-	const cases = await getCasesByUser(userId)
+	const search = new URL(request.url).searchParams.get('search')
+	const cases = await getCasesByUser(userId, search)
 
-	return data({ cases })
+	return data({ cases, search })
 }
 
 export default function Cases({
 	loaderData,
 	// actionData,
 }: Route.ComponentProps) {
-	const { cases } = loaderData
+	const { cases, search } = loaderData
+	const submit = useSubmit()
 
 	return (
 		<div className="container mx-auto p-6">
-			<div className="flex items-center justify-between">
-				<h1 className="mb-6 text-3xl font-bold">Cases</h1>
-				<Link
-					to="/cases/new"
-					className="rounded bg-green-600 px-4 py-2 text-white hover:bg-green-700"
-				>
-					Create New Case
-				</Link>
+			<div className="mb-4 flex flex-col gap-4 md:mb-6 md:flex-row md:items-center md:justify-between">
+				<h1 className="text-3xl font-bold">Cases</h1>
+				<div className="flex flex-1 flex-col gap-3 md:flex-row md:items-center md:justify-end">
+					<Form
+						method="GET"
+						action="/cases"
+						className="relative flex w-full max-w-sm"
+						onChange={(event) => submit(event.currentTarget)}
+					>
+						<div className="absolute left-4 top-1/2 -translate-y-1/2">
+							<Icon
+								name="magnifying-glass"
+								className="h-5 w-5 text-emerald-600"
+							/>
+						</div>
+						<input
+							type="search"
+							name="search"
+							defaultValue={search ?? ''}
+							placeholder="Search by homeowner or location"
+							className="w-full rounded-full border-2 border-emerald-500 bg-white py-2.5 pl-12 pr-4 text-sm shadow-md transition-all focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+						/>
+					</Form>
+					<Link
+						to="/cases/new"
+						className="inline-flex items-center justify-center rounded-lg bg-emerald-600 px-6 py-3 font-semibold text-white transition-all hover:bg-emerald-700"
+					>
+						Create New Case
+					</Link>
+				</div>
 			</div>
-			/* TODO:why /new why not case/new */
 			{cases.length === 0 ? (
 				<div className="mt-8 rounded-lg border-2 border-gray-200 p-8 text-center">
 					<h2 className="mb-2 text-xl font-medium text-gray-600">
-						No Cases Found
+						{search && search.trim().length > 0
+							? `No cases found for "${search}".`
+							: 'No Cases Found'}
 					</h2>
 					<p className="mb-4 text-gray-500">
 						Get started by creating your first case analysis.
 					</p>
 					<Link
 						to="/cases/new"
-						className="inline-block rounded bg-green-600 px-4 py-2 text-white hover:bg-green-700"
+						className="inline-block rounded-lg bg-emerald-600 px-6 py-3 font-semibold text-white transition-all hover:bg-emerald-700"
 					>
 						📈 Create New Case
 					</Link>
@@ -58,7 +84,7 @@ export default function Cases({
 									scope="col"
 									className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500"
 								>
-									Home Owner
+									Homeowner
 								</th>
 								<th
 									scope="col"

--- a/heat-stack/app/utils/db/case.server.ts
+++ b/heat-stack/app/utils/db/case.server.ts
@@ -72,15 +72,73 @@ export const deleteCaseWithUser = async (caseId: number, userId: string) => {
 	})
 }
 
-export const getCasesByUser = async (userId: string) => {
+export const getCasesByUser = async (
+	userId: string,
+	search?: string | null,
+) => {
+	const where =
+		search && search.trim().length > 0
+			? {
+					users: {
+						some: {
+							id: userId,
+						},
+					},
+					OR: [
+						{
+							homeOwner: {
+								OR: [
+									{
+										firstName1: {
+											contains: search,
+										},
+									},
+									{
+										lastName1: {
+											contains: search,
+										},
+									},
+								],
+							},
+						},
+						{
+							location: {
+								OR: [
+									{
+										address: {
+											contains: search,
+										},
+									},
+									{
+										city: {
+											contains: search,
+										},
+									},
+									{
+										state: {
+											contains: search,
+										},
+									},
+									{
+										zipcode: {
+											contains: search,
+										},
+									},
+								],
+							},
+						},
+					],
+				}
+			: {
+					users: {
+						some: {
+							id: userId,
+						},
+					},
+				}
+
 	return await prisma.case.findMany({
-		where: {
-			users: {
-				some: {
-					id: userId,
-				},
-			},
-		},
+		where,
 		include: {
 			homeOwner: true,
 			location: true,


### PR DESCRIPTION
**Description**

Adds a search bar to the Cases page that lets users quickly filter their own cases by home owner name and location fields.

Closes #630

**Changes**

- Added optional `search` parameter to `getCasesByUser` to support filtering by home owner and location fields (address, city, state, zipcode).  
- Updated `cases+/index.tsx` loader to read the `search` query param and pass it to the DB helper.  
- Added a search form on the Cases page header that submits via `GET /cases` and auto-refreshes results when the query changes or is cleared.  
- Improved the empty state message to show when no cases match the current search term.

**UI Improvements:**
- Changed the search bar style.
- Added magnifying glass icon inside the search input.
- Removed the separate "Search" button — search now auto-submits on input change.
- Updated "Create New Case" button styling to match home page.
- Updated placeholder text.
- Changed "Home Owner" labels to "Homeowner".

**Testing:**
- Visited `/cases` with multiple cases for the same user.
- Searched by homeowner name (full and partial matches).
- Searched by location fields (street address, city, state, zipcode).
- Verified that clearing the search input (including using the browser's clear "×" button) automatically refreshes to show all cases.
- Confirmed search only returns cases belonging to the logged-in user.
- Verified UI styling matches design specifications (emerald colors, rounded search bar, icon placement).

<img width="1390" height="664" alt="1" src="https://github.com/user-attachments/assets/c584da5d-a8bd-4d11-a09f-ef060f094a68" />
<img width="1373" height="393" alt="2" src="https://github.com/user-attachments/assets/e774ee1c-3a6e-4bcb-92a3-ba29b2f93218" />
<img width="1379" height="412" alt="3" src="https://github.com/user-attachments/assets/2d2cf7a1-058a-4bfa-9ae4-5b0dff9a828d" />
