### PR TITLE
Removed help button on heat load analysis

### DIFF
--- a/heat-stack/app/components/ui/heat/CaseSummaryComponents/AnalysisHeader.tsx
+++ b/heat-stack/app/components/ui/heat/CaseSummaryComponents/AnalysisHeader.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef } from 'react'
 import { type UsageDataSchema } from '#/types/types.ts'
-import { HelpButton } from '../../HelpButton'
 
 interface AnalysisHeaderProps {
 	usageData: UsageDataSchema
@@ -116,8 +115,6 @@ export function AnalysisHeader({
 				<h2 className={`${titleClassTailwind} ${componentMargin}`}>
 					Heat Load Analysis
 				</h2>
-				{/* TODO: add help text here */}
-				<HelpButton keyName="heat_load_analysis.help" />
 			</div>
 			<div
 				data-pw="analysis-header"


### PR DESCRIPTION
The removal of the help button on the heat load analysis is completed. The pictures are included to demonstrate the removal of the small icon.


Before:
<img width="1980" height="362" alt="0F79436A-CCEA-4369-A89D-F417A65AC067" src="https://github.com/user-attachments/assets/d798d8e4-c07e-49c1-b223-2d6bfe571fe6" />

After:
<img width="1980" height="348" alt="8567B160-A9DA-4C3A-AD2D-CF362C3BE319" src="https://github.com/user-attachments/assets/4ef0adf8-6a69-4d33-86ab-f67f2f556196" />