### PR TITLE
Update UI and add some validation for design temp override

### DIFF
--- a/heat-stack/app/components/ui/heat/CaseSummaryComponents/HomeInformation.tsx
+++ b/heat-stack/app/components/ui/heat/CaseSummaryComponents/HomeInformation.tsx
@@ -198,8 +198,16 @@ export function HomeInformation(props: HomeInformationProps) {
 				<div className="mt-4 flex space-x-4">
 					<div className="basis-1/2">
 						<Label>
-							County-Level Design Temperature is {JSON.stringify(executeLookupDesignTempToDisplay(geoStateId, geoCountyId))} °F
+							County-Level Design Temperature
 						</Label>
+
+						<div className="item font-bold mt-4">
+							{JSON.stringify(executeLookupDesignTempToDisplay(geoStateId, geoCountyId))} °F
+						</div>
+						<span className={descriptiveClass}>
+							This value is calculated from the address and will be used unless an override value is entered.
+						</span>
+
 					</div>
 
 					<div className="basis-1/2">
@@ -210,22 +218,20 @@ export function HomeInformation(props: HomeInformationProps) {
 
 						<HelpButton keyName="design_temperature_override.help" className="ml-[1ch]" />
 
-						<div className={componentMargin}>
-							<div className="mt-4 flex space-x-4">
-								<div>
-									<Input {...getInputProps(props.fields.design_temperature_override, { type: 'number' })} />
-									<div className="min-h-[32px] px-4 pb-3 pt-1">
-										<ErrorList
-											id={props.fields.design_temperature_override.errorId}
-											errors={props.fields.design_temperature_override.errors}
-										/>
-									</div>
+						<div className="mt-4 flex space-x-4">
+							<div>
+								<Input {...getInputProps(props.fields.design_temperature_override, { type: 'number' })} />
+								<span className={`${descriptiveClass}`}>
+									Enter a value in the range -10 to 32
+								</span>
+								<div className="min-h-[32px] px-4 pb-3 pt-1">
+									<ErrorList
+										id={props.fields.design_temperature_override.errorId}
+										errors={props.fields.design_temperature_override.errors}
+									/>
 								</div>
 							</div>
 						</div>
-						<span className={descriptiveClass}>
-							If a value is entered, it will be used in place of the County-Level Design Temperature
-						</span>
 					</div>
 
 

--- a/heat-stack/types/index.ts
+++ b/heat-stack/types/index.ts
@@ -46,7 +46,11 @@ export const HomeSchema = z.object({
 	 */
 	living_area: z.number().min(500).max(10000),
 	fuel_type: z.enum(['GAS', 'OIL', 'PROPANE']),
-	design_temperature_override: z.number().optional(),
+	design_temperature_override: z
+    .number()
+    .min(-10, {message: "Override value can't be below -10"})
+    .max(32, {message: 'Override value cannot exceed 32'})
+    .optional(),
 	/**
 	 * unit: percentage in decimal numbers, but not 0 to 1
 	 */


### PR DESCRIPTION
Made some updates based on issue description and this comment: https://github.com/codeforboston/home-energy-analysis-tool/issues/341#issuecomment-3693161901
<img width="2226" height="484" alt="CleanShot 2026-01-06 at 01 53 33@2x" src="https://github.com/user-attachments/assets/7dec5a4c-c4fc-4f34-a4a5-c1ab900bdbe4" />

Won't fix the whole issue as it's still missing the actual calculation/rules engine portion of the code. I haven't really been able to test the calculation because I don't have an example csv for it