### PR TITLE
comment out safeDelete memory leak prevention for demo

### DIFF
--- a/heat-stack/app/utils/hooks/use-rules-engine.ts
+++ b/heat-stack/app/utils/hooks/use-rules-engine.ts
@@ -175,15 +175,15 @@ export const useRulesEngine = (
 	}
 
 	// shutdown pyodide when component unmounts
-	useEffect(() => {
-		return () => {
-			// Memory cleanup of pyodide fn's when component unmounts
-			if (rulesEngineRef.current?.cleanupPyodideProxies) {
-				rulesEngineRef.current.cleanupPyodideProxies()
-				rulesEngineRef.current = null
-			}
-		}
-	}, [])
+	// useEffect(() => {
+	// 	return () => {
+	// 		// Memory cleanup of pyodide fn's when component unmounts
+	// 		if (rulesEngineRef.current?.cleanupPyodideProxies) {
+	// 			rulesEngineRef.current.cleanupPyodideProxies()
+	// 			rulesEngineRef.current = null
+	// 		}
+	// 	}
+	// }, [])
 
 	// reset usage data as a result of user submitting a new bill
 	useEffect(() => {


### PR DESCRIPTION
Ensemble coding:
- [x] from #660, "Recalculation Failed An error occurred during recalculation: Object has already been
destroyed" 