### PR TITLE
Fix #664: Use Analysis ID for View link

### DIFF
--- a/heat-stack/app/routes/cases+/index.tsx
+++ b/heat-stack/app/routes/cases+/index.tsx
@@ -170,7 +170,7 @@ export default function Cases({
 										</td>
 										<td className="whitespace-nowrap px-6 py-4">
 											<Link
-												to={`/cases/${caseItem.id}`}
+												to={`/cases/${firstAnalysis?.id}`}
 												className="mx-1 text-indigo-600 hover:text-indigo-900"
 											>
 												View


### PR DESCRIPTION
Restored View link to use `firstAnalysis?.id` (Analysis ID) instead of `caseItem.id`.

This was accidentally changed in PR #663 but needs to use Analysis ID to correctly route to viewing specific analysis results.