### PR TITLE
Fix #314: Make Setback Temperature and Setback hours per day truly optional

### DIFF
--- a/heat-stack/app/routes/cases+/$analysisid.tsx
+++ b/heat-stack/app/routes/cases+/$analysisid.tsx
@@ -133,10 +133,15 @@ export default function Analysis({
 						</p>
 						<p>
 							<span className="font-medium">Setback Temperature:</span>{' '}
-							{heatingInput.setbackTemperature}°F
+							{heatingInput.setbackTemperature != null
+								? `${heatingInput.setbackTemperature}°F`
+								: 'N/A'}
 						</p>
 						<p>
-							<span className="font-medium">Setback Hours Per Day:</span>{' '}
+							<span className="font-medium">Setback Hours:</span>{' '}
+							{heatingInput.setbackHoursPerDay != null
+								? `${heatingInput.setbackHoursPerDay} hours/day`
+								: 'N/A'}
 						</p>
 						<p>
 							<span className="font-medium">Number of Occupants:</span>{' '}

--- a/heat-stack/app/routes/cases+/$caseId.edit.tsx
+++ b/heat-stack/app/routes/cases+/$caseId.edit.tsx
@@ -146,8 +146,8 @@ export async function loader({ params, request }: Route.LoaderArgs) {
 			'Invalid heating system efficiency value detected',
 		),
 		thermostat_set_point: heatingInput.thermostatSetPoint,
-		setback_temperature: heatingInput.setbackTemperature,
-		setback_hours_per_day: heatingInput.setbackHoursPerDay,
+		setback_temperature: heatingInput.setbackTemperature ?? undefined,
+		setback_hours_per_day: heatingInput.setbackHoursPerDay ?? undefined,
 		design_temperature_override: heatingInput.designTemperatureOverride ? 1 : 0,
 		// design_temperature: 12 /* TODO:  see #162 and esp. #123*/
 	})

--- a/heat-stack/app/utils/db/case.db.server.ts
+++ b/heat-stack/app/utils/db/case.db.server.ts
@@ -82,8 +82,8 @@ export async function createCaseRecord(
 						formValues.heating_system_efficiency * 100,
 					),
 					thermostatSetPoint: formValues.thermostat_set_point,
-					setbackTemperature: formValues.setback_temperature,
-					setbackHoursPerDay: formValues.setback_hours_per_day,
+					setbackTemperature: formValues.setback_temperature ?? null,
+					setbackHoursPerDay: formValues.setback_hours_per_day ?? null,
 					numberOfOccupants: 2, // Default value
 					estimatedWaterHeatingEfficiency: 80, // Default value
 					standByLosses: 10, // Default value
@@ -175,8 +175,8 @@ export async function updateCaseRecord(
 						formValues.heating_system_efficiency * 100,
 					),
 					thermostatSetPoint: formValues.thermostat_set_point,
-					setbackTemperature: formValues.setback_temperature,
-					setbackHoursPerDay: formValues.setback_hours_per_day,
+					setbackTemperature: formValues.setback_temperature ?? null,
+					setbackHoursPerDay: formValues.setback_hours_per_day ?? null,
 					livingArea: formValues.living_area,
 				},
 			})

--- a/heat-stack/app/utils/db/case.server.ts
+++ b/heat-stack/app/utils/db/case.server.ts
@@ -201,8 +201,8 @@ export const updateCase = async (
 				validHI.heating_system_efficiency * 100,
 			),
 			thermostatSetPoint: validHI.thermostat_set_point,
-			setbackTemperature: validHI.setback_temperature || 65,
-			setbackHoursPerDay: validHI.setback_hours_per_day || 0,
+			setbackTemperature: validHI.setback_temperature ?? null,
+			setbackHoursPerDay: validHI.setback_hours_per_day ?? null,
 			numberOfOccupants: 2, // Default value until we add to form
 			estimatedWaterHeatingEfficiency: 80, // Default value until we add to form
 			standByLosses: 5, // Default value until we add to form
@@ -287,8 +287,8 @@ export const createCase = async (
 					formInputs.heating_system_efficiency * 100,
 				),
 				thermostatSetPoint: formInputs.thermostat_set_point,
-				setbackTemperature: formInputs.setback_temperature || 65,
-				setbackHoursPerDay: formInputs.setback_hours_per_day || 0,
+				setbackTemperature: formInputs.setback_temperature ?? null,
+				setbackHoursPerDay: formInputs.setback_hours_per_day ?? null,
 				numberOfOccupants: 2, // Default value until we add to form
 				estimatedWaterHeatingEfficiency: 80, // Default value until we add to form
 				standByLosses: 5, // Default value until we add to form

--- a/heat-stack/prisma/migrations/20260206230306_make_setback_fields_optional/migration.sql
+++ b/heat-stack/prisma/migrations/20260206230306_make_setback_fields_optional/migration.sql
@@ -1,0 +1,23 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_HeatingInput" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "analysisId" INTEGER NOT NULL,
+    "fuelType" TEXT NOT NULL,
+    "designTemperatureOverride" BOOLEAN NOT NULL,
+    "heatingSystemEfficiency" INTEGER NOT NULL,
+    "thermostatSetPoint" INTEGER NOT NULL,
+    "setbackTemperature" INTEGER,
+    "setbackHoursPerDay" INTEGER,
+    "numberOfOccupants" INTEGER NOT NULL,
+    "estimatedWaterHeatingEfficiency" INTEGER NOT NULL,
+    "standByLosses" INTEGER NOT NULL,
+    "livingArea" REAL NOT NULL,
+    CONSTRAINT "HeatingInput_analysisId_fkey" FOREIGN KEY ("analysisId") REFERENCES "Analysis" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_HeatingInput" ("id", "analysisId", "fuelType", "designTemperatureOverride", "heatingSystemEfficiency", "thermostatSetPoint", "setbackTemperature", "setbackHoursPerDay", "numberOfOccupants", "estimatedWaterHeatingEfficiency", "standByLosses", "livingArea") SELECT "id", "analysisId", "fuelType", "designTemperatureOverride", "heatingSystemEfficiency", "thermostatSetPoint", "setbackTemperature", "setbackHoursPerDay", "numberOfOccupants", "estimatedWaterHeatingEfficiency", "standByLosses", "livingArea" FROM "HeatingInput";
+DROP TABLE "HeatingInput";
+ALTER TABLE "new_HeatingInput" RENAME TO "HeatingInput";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/heat-stack/prisma/schema.prisma
+++ b/heat-stack/prisma/schema.prisma
@@ -204,8 +204,8 @@ model HeatingInput {
   designTemperatureOverride       Boolean
   heatingSystemEfficiency         Int
   thermostatSetPoint              Int
-  setbackTemperature              Int
-  setbackHoursPerDay              Int
+  setbackTemperature              Int?
+  setbackHoursPerDay              Int?
   numberOfOccupants               Int
   estimatedWaterHeatingEfficiency Int
   standByLosses                   Int

--- a/heat-stack/types/index.ts
+++ b/heat-stack/types/index.ts
@@ -55,8 +55,22 @@ export const HomeSchema = z.object({
 		.min(0.6, { message: 'Efficiency must be at least 60%' })
 		.max(1, { message: 'Efficiency cannot exceed 100%' }),
 	thermostat_set_point: z.number(),
-	setback_temperature: z.number().optional(),
-	setback_hours_per_day: z.number().optional(),
+	setback_temperature: z
+		.union([z.number(), z.string()])
+		.optional()
+		.transform((val) => {
+			if (val === '' || val === undefined || val === null) return undefined
+			const num = Number(val)
+			return isNaN(num) ? undefined : num
+		}),
+	setback_hours_per_day: z
+		.union([z.number(), z.string()])
+		.optional()
+		.transform((val) => {
+			if (val === '' || val === undefined || val === null) return undefined
+			const num = Number(val)
+			return isNaN(num) ? undefined : num
+		}),
 	numberOfOccupants: z.number(),
 	estimatedWaterHeatingEfficiency: z.number(),
 	standByLosses: z.number(),


### PR DESCRIPTION
## Summary
- Fix Zod schema to handle empty string form inputs for optional setback fields using `z.preprocess`
- Make `setbackTemperature` and `setbackHoursPerDay` nullable in Prisma schema (`Int` → `Int?`)
- Replace hardcoded defaults (`|| 65` / `|| 0`) with `?? null` in `createCase` and `updateCase`
- Handle null values in edit page (show empty field) and analysis display page (show "N/A")
- Allow users to clear previously filled setback values (change from filled → empty)

 ## Migration
- Added database migration to allow NULL values for setback fields 

## Test
- [x] Leave Setback Temperature and Setback hours per day empty → form submits successfully
- [x] Fill in setback fields → values are saved and displayed correctly
- [x] View case details with empty setback fields → shows "N/A"
- [x] Edit case with empty setback fields → fields remain empty (not pre-filled with defaults)
- [x] Edit case with filled setback fields → user can clear the values and they become "N/A"
<img width="1172" height="222" alt="1" src="https://github.com/user-attachments/assets/9823e1e4-1cee-408e-8d32-5810c006874d" />

<img width="1042" height="206" alt="2" src="https://github.com/user-attachments/assets/32c29d4e-e5dc-4eec-9885-9307c36db28e" />

- [x] add house values ,leave file unloaded → got to view cases page → “view” analysis for case → see that the house values are correct
<img width="764" height="259" alt="5566" src="https://github.com/user-attachments/assets/33cc9b10-fef0-4e3e-816c-021a129f8a27" />
