### PR TITLE
fix/642/signup page now has firstname and lastname

### DIFF
--- a/heat-stack/app/routes/_auth+/onboarding.tsx
+++ b/heat-stack/app/routes/_auth+/onboarding.tsx
@@ -14,7 +14,6 @@ import { useIsPending } from '#app/utils/misc.tsx'
 import { authSessionStorage } from '#app/utils/session.server.ts'
 import { redirectWithToast } from '#app/utils/toast.server.ts'
 import {
-	NameSchema,
 	PasswordAndConfirmPasswordSchema,
 	UsernameSchema,
 } from '#app/utils/user-validation.ts'

--- a/heat-stack/app/routes/_auth+/onboarding.tsx
+++ b/heat-stack/app/routes/_auth+/onboarding.tsx
@@ -79,7 +79,9 @@ export const US_STATES = [
 const SignupFormSchema = z
 	.object({
 		username: UsernameSchema,
-		name: NameSchema,
+		// name: NameSchema,
+		firstName: z.string().min(3, 'First name is required'),
+    	lastName: z.string().min(1, 'Last name is required'),
 		city: z.string().min(3, 'City/Town is required'),
 		state: z.enum(US_STATES, {
 			errorMap: () => ({ message: 'Please pick a state' }),
@@ -132,8 +134,19 @@ export async function action({ request }: Route.ActionArgs) {
 			}).transform(async (data) => {
 				if (intent !== null) return { ...data, session: null }
 
-				const session = await signup({ ...data, email })
-				return { ...data, session }
+				const formattedName = `${data.lastName}, ${data.firstName}`
+
+				const session = await signup({
+					...data,
+					email,
+					name: formattedName,
+				})
+
+				return {
+					...data,
+					name: formattedName,
+					session,
+				}
 			}),
 		async: true,
 	})
@@ -220,12 +233,27 @@ export default function OnboardingRoute({
 						errors={fields.username.errors}
 					/>
 					<Field
-						labelProps={{ htmlFor: fields.name.id, children: 'Name' }}
-						inputProps={{
-							...getInputProps(fields.name, { type: 'text' }),
-							autoComplete: 'name',
+						labelProps={{
+							htmlFor: fields.firstName.id,
+							children: 'First Name',
 						}}
-						errors={fields.name.errors}
+						inputProps={{
+							...getInputProps(fields.firstName, { type: 'text' }),
+							autoComplete: 'given-name',
+						}}
+						errors={fields.firstName.errors}
+					/>
+
+					<Field
+						labelProps={{
+							htmlFor: fields.lastName.id,
+							children: 'Last Name',
+						}}
+						inputProps={{
+							...getInputProps(fields.lastName, { type: 'text' }),
+							autoComplete: 'family-name',
+						}}
+						errors={fields.lastName.errors}
 					/>
 					<Field
 						labelProps={{

--- a/heat-stack/app/routes/_auth+/onboarding.tsx
+++ b/heat-stack/app/routes/_auth+/onboarding.tsx
@@ -78,7 +78,6 @@ export const US_STATES = [
 const SignupFormSchema = z
 	.object({
 		username: UsernameSchema,
-		// name: NameSchema,
 		firstName: z.string().min(3, 'First name is required'),
 		lastName: z.string().min(1, 'Last name is required'),
 		city: z.string().min(3, 'City/Town is required'),

--- a/heat-stack/app/routes/_auth+/onboarding.tsx
+++ b/heat-stack/app/routes/_auth+/onboarding.tsx
@@ -80,7 +80,7 @@ const SignupFormSchema = z
 		username: UsernameSchema,
 		// name: NameSchema,
 		firstName: z.string().min(3, 'First name is required'),
-    	lastName: z.string().min(1, 'Last name is required'),
+		lastName: z.string().min(1, 'Last name is required'),
 		city: z.string().min(3, 'City/Town is required'),
 		state: z.enum(US_STATES, {
 			errorMap: () => ({ message: 'Please pick a state' }),

--- a/heat-stack/tests/e2e/onboarding.test.ts
+++ b/heat-stack/tests/e2e/onboarding.test.ts
@@ -23,6 +23,8 @@ function extractUrl(text: string) {
 const test = base.extend<{
 	getOnboardingData(): {
 		username: string
+		firstName: string
+		lastName: string
 		name: string
 		city: string
 		state: string
@@ -32,9 +34,14 @@ const test = base.extend<{
 }>({
 	getOnboardingData: async ({}, use) => {
 		const userData = createUser()
+		const parts = userData.name.split(' ')
+		const firstName = parts[0]!
+		const lastName = parts.slice(1).join(' ')
 		await use(() => {
 			const onboardingData = {
 				...userData,
+				firstName,
+				lastName,
 				password: faker.internet.password(),
 				city: 'Boston',
 				state: 'MA',
@@ -88,7 +95,13 @@ test('onboarding with link', async ({ page, getOnboardingData }) => {
 		.getByRole('textbox', { name: /^username/i })
 		.fill(onboardingData.username)
 
-	await page.getByRole('textbox', { name: /^name/i }).fill(onboardingData.name)
+	await page.getByRole('textbox', { name: /first name/i })
+		.fill(onboardingData.firstName)
+
+	await page.getByRole('textbox', { name: /last name/i })
+		.fill(onboardingData.lastName)
+
+	// await page.getByRole('textbox', { name: /^name/i }).fill(onboardingData.name)
 
 	await page.getByRole('textbox', { name: /city/i }).fill(onboardingData.city)
 

--- a/heat-stack/tests/e2e/onboarding.test.ts
+++ b/heat-stack/tests/e2e/onboarding.test.ts
@@ -103,8 +103,6 @@ test('onboarding with link', async ({ page, getOnboardingData }) => {
 		.getByRole('textbox', { name: /last name/i })
 		.fill(onboardingData.lastName)
 
-	// await page.getByRole('textbox', { name: /^name/i }).fill(onboardingData.name)
-
 	await page.getByRole('textbox', { name: /city/i }).fill(onboardingData.city)
 
 	await page.getByLabel(/state/i).selectOption(onboardingData.state)

--- a/heat-stack/tests/e2e/onboarding.test.ts
+++ b/heat-stack/tests/e2e/onboarding.test.ts
@@ -95,10 +95,12 @@ test('onboarding with link', async ({ page, getOnboardingData }) => {
 		.getByRole('textbox', { name: /^username/i })
 		.fill(onboardingData.username)
 
-	await page.getByRole('textbox', { name: /first name/i })
+	await page
+		.getByRole('textbox', { name: /first name/i })
 		.fill(onboardingData.firstName)
 
-	await page.getByRole('textbox', { name: /last name/i })
+	await page
+		.getByRole('textbox', { name: /last name/i })
 		.fill(onboardingData.lastName)
 
 	// await page.getByRole('textbox', { name: /^name/i }).fill(onboardingData.name)


### PR DESCRIPTION
Sign up page now has separate first name and last name fields which combine to "Last, First" in the name field.

closes #642 

<img width="355" height="434" alt="image" src="https://github.com/user-attachments/assets/58347f6b-485c-4f5e-9d00-d98f56c9193c" />
 
<img width="671" height="319" alt="image" src="https://github.com/user-attachments/assets/c332d963-4f78-41b1-8092-0de38d9e8470" />
