### PR TITLE
fix: replace raw input and button elements with project UI components

### DIFF
--- a/heat-stack/app/routes/admin+/cache.tsx
+++ b/heat-stack/app/routes/admin+/cache.tsx
@@ -107,12 +107,13 @@ export default function CacheAdminRoute({ loaderData }: Route.ComponentProps) {
 			>
 				<div className="flex-1">
 					<div className="flex flex-1 gap-4">
-						<button
+						<Button
 							type="submit"
+							variant="ghost"
 							className="flex h-16 items-center justify-center"
 						>
 							🔎
-						</button>
+						</Button>
 						<Field
 							className="flex-1"
 							labelProps={{ children: 'Search' }}

--- a/heat-stack/app/routes/cases+/index.tsx
+++ b/heat-stack/app/routes/cases+/index.tsx
@@ -2,6 +2,7 @@ import Fuse from 'fuse.js'
 import { useMemo } from 'react'
 import { Form, data, Link, useSubmit } from 'react-router'
 import { Icon } from '#app/components/ui/icon.tsx'
+import { Input } from '#app/components/ui/input.tsx'
 import {
 	getCases,
 	getLoggedInUserFromRequest,
@@ -72,7 +73,7 @@ export default function Cases({
 								className="h-5 w-5 text-emerald-600"
 							/>
 						</div>
-						<input
+						<Input
 							type="search"
 							name="search"
 							defaultValue={search ?? ''}

--- a/heat-stack/app/routes/resources+/theme-switch.tsx
+++ b/heat-stack/app/routes/resources+/theme-switch.tsx
@@ -4,6 +4,7 @@ import { invariantResponse } from '@epic-web/invariant'
 import { data, redirect, useFetcher, useFetchers } from 'react-router'
 import { ServerOnly } from 'remix-utils/server-only'
 import { z } from 'zod'
+import { Button } from '#app/components/ui/button.tsx'
 import { Icon } from '#app/components/ui/icon.tsx'
 import { useHints, useOptionalHints } from '#app/utils/client-hints.tsx'
 import {
@@ -86,12 +87,14 @@ export function ThemeSwitch({
 			</ServerOnly>
 			<input type="hidden" name="theme" value={nextMode} />
 			<div className="flex gap-2">
-				<button
+				<Button
 					type="submit"
+					variant="ghost"
+					size="icon"
 					className="flex h-8 w-8 cursor-pointer items-center justify-center"
 				>
 					{modeLabel[mode]}
-				</button>
+				</Button>
 			</div>
 		</fetcher.Form>
 	)

--- a/heat-stack/app/routes/users+/index.tsx
+++ b/heat-stack/app/routes/users+/index.tsx
@@ -2,7 +2,9 @@ import Fuse from 'fuse.js'
 import { useMemo, useState } from 'react'
 import { Form, useLoaderData } from 'react-router'
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx'
+import { Button } from '#app/components/ui/button.tsx'
 import { Icon } from '#app/components/ui/icon.tsx'
+import { Input } from '#app/components/ui/input.tsx'
 import { ACCESS_DENIED_MESSAGE } from '#app/constants/error-messages.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import { useOptionalUser, hasAdminRole } from '#app/utils/user.ts'
@@ -110,7 +112,7 @@ export default function AdminEditUsers() {
 							/>
 						</div>
 
-						<input
+						<Input
 							type="search"
 							name="search"
 							placeholder="Search users..."
@@ -177,14 +179,15 @@ export default function AdminEditUsers() {
 										/>
 									</div>
 
-									<button
+									<Button
 										type="button"
+										variant="ghost"
 										className="ml-2 rounded p-2 hover:bg-accent"
 										id={`edit_btn_${u.username}`}
 										onClick={() => setEditingId(u.id)}
 									>
 										<Icon name="pencil-2" size="md" />
-									</button>
+									</Button>
 								</div>
 							) : (
 								<Form
@@ -237,14 +240,15 @@ export default function AdminEditUsers() {
 											onChange={(e) => e.target.form?.requestSubmit()}
 										/>
 									</div>
-									<button
+									<Button
 										type="button"
+										variant="ghost"
 										className="ml-2 rounded p-2 hover:bg-accent"
 										id={`cancel_edit_btn_${u.username}`}
 										onClick={() => setEditingId(null)}
 									>
 										<Icon name="cross-1" size="md" />
-									</button>
+									</Button>
 								</Form>
 							)}
 						</li>


### PR DESCRIPTION
Related to #719

Replaced raw HTML elements with project UI components:
- cases+/index.tsx: <input type="search"> → <Input>
- users+/index.tsx: <input type="search"> and form inputs → <Input>, <button> → <Button>
- admin+/cache.tsx: <button> → <Button>
- resources+/theme-switch.tsx: <button> → <Button>

Skipped <select> and <input type="checkbox"> as those require 
complex Radix UI compound component patterns.