### PR TITLE
fix/327/made chart more accessible by changing point shape, size and line wid…

### DIFF
--- a/heat-stack/app/components/ui/heat/CaseSummaryComponents/Graphs/HeatLoad.tsx
+++ b/heat-stack/app/components/ui/heat/CaseSummaryComponents/Graphs/HeatLoad.tsx
@@ -23,6 +23,7 @@ import {
 } from '../utility/heat-load-calculations.ts'
 import { CustomLegend } from './HeatLoadGraphLegend.tsx'
 import { HeatLoadGraphToolTip } from './HeatLoadGraphToolTip.tsx'
+import { DiamondShape, SquareShape } from './HeatLoadScatterShapes.tsx'
 
 const X_AXIS_BUFFER_PERCENTAGE_MAX = 1.3 // 30% buffer
 const Y_AXIS_ROUNDING_UNIT = 10000 // Rounding unit for minY and maxY
@@ -148,15 +149,17 @@ export function HeatLoad({
 							type="monotone"
 							dataKey="maxLine"
 							stroke={COLOR_ORANGE}
+							strokeWidth={2}
 							dot={false}
 							name="Maximum, no internal or solar gain"
 						/>
 
-						{/* Line for average heat load */}
 						<Line
 							type="monotone"
 							dataKey="avgLine"
 							stroke={COLOR_BLUE}
+							strokeWidth={3}
+							strokeDasharray="8 4"
 							dot={false}
 							name="Average, with internal & solar gain"
 						/>
@@ -166,17 +169,16 @@ export function HeatLoad({
 							dataKey="maxPoint"
 							fill={COLOR_ORANGE}
 							name="Maximum at design temperature"
-							shape="diamond"
-							legendType="diamond"
+							shape={(props: any) => <DiamondShape {...props} />}
 						/>
 
 						{/* Scatter point for average heat load at design temperature */}
+
 						<Scatter
 							dataKey="avgPoint"
 							fill={COLOR_BLUE}
 							name="Average at design temperature"
-							shape="diamond"
-							legendType="diamond"
+							shape={(props: any) => <SquareShape {...props} />}
 						/>
 					</ComposedChart>
 				</ResponsiveContainer>

--- a/heat-stack/app/components/ui/heat/CaseSummaryComponents/Graphs/HeatLoadGraphLegend.tsx
+++ b/heat-stack/app/components/ui/heat/CaseSummaryComponents/Graphs/HeatLoadGraphLegend.tsx
@@ -11,33 +11,56 @@ export const CustomLegend = () => {
 			name: 'Average, with internal & solar gain',
 			color: COLOR_BLUE,
 			type: 'line',
+			dashed: true,
 		},
 		{
 			name: 'Maximum at design temperature',
 			color: COLOR_ORANGE,
-			type: 'diamond',
+			shape: 'diamond',
 		},
 		{
 			name: 'Average at design temperature',
 			color: COLOR_BLUE,
-			type: 'diamond',
+			shape: 'square',
 		},
 	]
+
+	const LineIcon = ({ color, dashed }: { color: string; dashed?: boolean }) => (
+		<svg width="32" height="10">
+			<line
+				x1="0"
+				y1="5"
+				x2="32"
+				y2="5"
+				stroke={color}
+				strokeWidth="3"
+				strokeDasharray={dashed ? '8 4' : undefined}
+			/>
+		</svg>
+	)
+
+	const DiamondIcon = ({ color }: { color: string }) => (
+		<svg width="16" height="16">
+			<polygon points="8,1 15,8 8,15 1,8" fill={color} />
+		</svg>
+	)
+
+	const SquareIcon = ({ color }: { color: string }) => (
+		<svg width="16" height="16">
+			<rect x="2" y="2" width="12" height="12" fill={color} />
+		</svg>
+	)
 
 	return (
 		<div className="absolute right-6 top-6 rounded border border-gray-200 bg-white p-4 shadow-sm">
 			{legendItems.map((item, index) => (
 				<div key={index} className="mb-2 flex items-center gap-2 last:mb-0">
 					{item.type === 'line' ? (
-						<div
-							className="h-0.5 w-8"
-							style={{ backgroundColor: item.color }}
-						/>
+						<LineIcon color={item.color} dashed={item.dashed} />
+					) : item.shape === 'diamond' ? (
+						<DiamondIcon color={item.color} />
 					) : (
-						<div
-							className="h-3 w-3 rotate-45"
-							style={{ backgroundColor: item.color }}
-						/>
+						<SquareIcon color={item.color} />
 					)}
 					<span className="text-sm">{item.name}</span>
 				</div>

--- a/heat-stack/app/components/ui/heat/CaseSummaryComponents/Graphs/HeatLoadScatterShapes.tsx
+++ b/heat-stack/app/components/ui/heat/CaseSummaryComponents/Graphs/HeatLoadScatterShapes.tsx
@@ -1,0 +1,42 @@
+type ShapeProps = {
+	cx?: number
+	cy?: number
+	fill?: string
+}
+
+export function DiamondShape({ cx, cy, fill = '#000' }: ShapeProps) {
+	if (cx == null || cy == null) {
+		return null
+	}
+	const size = 10
+
+	return (
+		<polygon
+			points={`
+        ${cx},${cy - size}
+        ${cx + size},${cy}
+        ${cx},${cy + size}
+        ${cx - size},${cy}
+      `}
+			fill={fill}
+		/>
+	)
+}
+
+export function SquareShape({ cx, cy, fill = '#000' }: ShapeProps) {
+	if (cx == null || cy == null) {
+		return null
+	}
+
+	const size = 8
+
+	return (
+		<rect
+			x={cx - size}
+			y={cy - size}
+			width={size * 2}
+			height={size * 2}
+			fill={fill}
+		/>
+	)
+}


### PR DESCRIPTION
…th and type

closes #327 

before:
<img width="1079" height="503" alt="Screenshot 2026-07-02 163132" src="https://github.com/user-attachments/assets/1c6cd630-450c-4c5c-98d7-136af8a60d58" />



after:
<img width="1081" height="493" alt="image" src="https://github.com/user-attachments/assets/abc6a67a-4861-476f-8a29-3e4cce15005d" />

updated the scatter point shape type and size. Also updated the line type and width for more accessibility for users with color vision deficiencies. The legend has been updated to match the changes.