### PR TITLE
fix/560/updated the energy-analysis test to use test id instead of name to id…

### DIFF
--- a/heat-stack/app/routes/_heat+/index.tsx
+++ b/heat-stack/app/routes/_heat+/index.tsx
@@ -25,6 +25,7 @@ export default function HEATLandingPage() {
 						<Link
 							to="/cases/new?dev=true"
 							className="inline-block rounded-lg bg-white px-8 py-4 font-semibold text-emerald-700 shadow-lg transition-all hover:shadow-xl"
+							data-testid="get-started-demo-data"
 						>
 							Get Started (with Demo Data)
 						</Link>

--- a/heat-stack/tests/e2e/energy-analysis.test.ts
+++ b/heat-stack/tests/e2e/energy-analysis.test.ts
@@ -54,7 +54,7 @@ test('Logged out user can upload CSV, toggle table row checkbox, expecting analy
 	await page.goto('/')
 
 	// click the "demo data" link
-	await page.getByText('Get Started (with Demo Data)').click()
+	await page.getByTestId('get-started-demo-data').click()
 
 	await uploadEnergyBill()
 
@@ -91,7 +91,7 @@ test.skip('Custom name persists after form submission', async ({
 	await page.goto('/')
 
 	// click the "demo data" link
-	await page.getByText('Get Started (with Demo Data)').click()
+	await page.getByTestId('get-started-demo-data').click()
 
 	// Get the name input field and verify it has the default value
 	let nameInput = page.locator('input[name="name"]')
@@ -143,7 +143,7 @@ test.skip('Upload multiple CSVs', async ({
 	await page.goto('/')
 
 	// click the "demo data" link
-	await page.getByText('Get Started (with Demo Data)').click()
+	await page.getByTestId('get-started-demo-data').click()
 
 	await uploadEnergyBill()
 


### PR DESCRIPTION
…entify buttons

<img width="809" height="196" alt="Screenshot 2026-07-03 180752" src="https://github.com/user-attachments/assets/7532fdc4-27bd-4460-99b7-8c6c0313a867" />


closes #560 