### PR TITLE
fix/781/solves CI test run for forked model 

### DIFF
--- a/heat-stack/app/utils/GeocodeUtil.ts
+++ b/heat-stack/app/utils/GeocodeUtil.ts
@@ -1,5 +1,8 @@
+const proxy = import.meta.env.VITE_CORS_PROXY_URL?.trim()
+
 const BASE_URL =
-	import.meta.env.VITE_CORS_PROXY_URL ?? 'https://geocoding.geo.census.gov'
+	proxy && proxy.length > 0 ? proxy : 'https://geocoding.geo.census.gov'
+
 const CORS_ORIGIN = import.meta.env.VITE_CORS_ORIGIN
 const ADDRESS_ENDPOINT = '/geocoder/geographies/onelineaddress'
 


### PR DESCRIPTION
closes #718 

VITE_CORS_PROXY_URL is unset (or resolves to an empty string) in forked GitHub Actions workflows. Using ?? only falls back for null/undefined, so an empty string resulted in BASE_URL being empty and new URL() throwing ERR_INVALID_URL. This change treats empty/whitespace values as "not configured" and falls back to the Census geocoder endpoint, allowing forked PR workflows to pass without additional configuration.