### PR TITLE
disable calculate button unless navigation idle

### DIFF
--- a/heat-stack/app/components/ui/heat/CaseSummaryComponents/EnergyUseUpload.tsx
+++ b/heat-stack/app/components/ui/heat/CaseSummaryComponents/EnergyUseUpload.tsx
@@ -1,10 +1,10 @@
-import {useState} from "react"
 import { Upload } from 'lucide-react'
+import { useNavigation } from 'react-router'
 import { Button } from '#/app/components/ui/button.tsx'
+import { Spinner } from '#app/components/spinner.tsx'
 import { CustomFileUpload } from '#app/components/ui/CustomFileUpload'
 import { ErrorList } from './ErrorList'
-import { Spinner } from '#app/components/spinner.tsx'
-import { useNavigation } from "react-router"
+
 
 interface EnergyUseUploadProps {
 	setScrollAfterSubmit: React.Dispatch<React.SetStateAction<boolean>>
@@ -18,9 +18,9 @@ export function EnergyUseUpload({
 	isEditMode = false,
 }: EnergyUseUploadProps) {
 	const titleClass = 'text-4xl font-bold tracking-wide mt-10'
-    const navigation = useNavigation()
-    const isIdle = navigation.state==="idle"
-    
+	const navigation = useNavigation()
+	const isIdle = navigation.state === 'idle'
+
 	/*
 	When the calculate button is pressed, sets scrollAfterSubmit to
 	true because we want the page to scroll then.
@@ -65,15 +65,14 @@ export function EnergyUseUpload({
 						type="submit"
 						name="intent"
 						value="upload"
-                        disabled={!isIdle}
+						disabled={!isIdle}
 						onClick={handleSubmit}
 						style={{ marginBottom: '20px' }}
 					>
-						{isIdle && <Upload className="mr-2 h-4 w-4"/>}
-                        <Spinner showSpinner={!isIdle}/>
+						{isIdle && <Upload className="mr-2 h-4 w-4" />}
+						<Spinner showSpinner={!isIdle} />
 						Calculate
 					</Button>
-                    
 				)}
 
 				<a

--- a/heat-stack/app/components/ui/heat/CaseSummaryComponents/EnergyUseUpload.tsx
+++ b/heat-stack/app/components/ui/heat/CaseSummaryComponents/EnergyUseUpload.tsx
@@ -5,7 +5,6 @@ import { Spinner } from '#app/components/spinner.tsx'
 import { CustomFileUpload } from '#app/components/ui/CustomFileUpload'
 import { ErrorList } from './ErrorList'
 
-
 interface EnergyUseUploadProps {
 	setScrollAfterSubmit: React.Dispatch<React.SetStateAction<boolean>>
 	fields: any

--- a/heat-stack/app/components/ui/heat/CaseSummaryComponents/EnergyUseUpload.tsx
+++ b/heat-stack/app/components/ui/heat/CaseSummaryComponents/EnergyUseUpload.tsx
@@ -1,7 +1,10 @@
+import {useState} from "react"
 import { Upload } from 'lucide-react'
 import { Button } from '#/app/components/ui/button.tsx'
 import { CustomFileUpload } from '#app/components/ui/CustomFileUpload'
 import { ErrorList } from './ErrorList'
+import { Spinner } from '#app/components/spinner.tsx'
+import { useNavigation } from "react-router"
 
 interface EnergyUseUploadProps {
 	setScrollAfterSubmit: React.Dispatch<React.SetStateAction<boolean>>
@@ -15,6 +18,9 @@ export function EnergyUseUpload({
 	isEditMode = false,
 }: EnergyUseUploadProps) {
 	const titleClass = 'text-4xl font-bold tracking-wide mt-10'
+    const navigation = useNavigation()
+    const isIdle = navigation.state==="idle"
+    
 	/*
 	When the calculate button is pressed, sets scrollAfterSubmit to
 	true because we want the page to scroll then.
@@ -59,12 +65,15 @@ export function EnergyUseUpload({
 						type="submit"
 						name="intent"
 						value="upload"
+                        disabled={!isIdle}
 						onClick={handleSubmit}
 						style={{ marginBottom: '20px' }}
 					>
-						<Upload className="mr-2 h-4 w-4" />
+						{isIdle && <Upload className="mr-2 h-4 w-4"/>}
+                        <Spinner showSpinner={!isIdle}/>
 						Calculate
 					</Button>
+                    
 				)}
 
 				<a


### PR DESCRIPTION
closes #615 

I made the button only work while the navigation component is idle.

<img width="494" height="232" alt="Recording 2026-07-13 at 17 06 47" src="https://github.com/user-attachments/assets/218fdfc9-ecf7-4ada-9172-567d6c506af6" />

This makes it so that even spam clicking the calculate button will only generate one new case.

I also added the spinner component from the spinner.tsx file in the project but it doesn't seem to show anything, at least on my machine. I decided to leave it anyway since it doesn't break anything and ideally if the component gets worked on later it will automatically improve the user experience for this page.