### PR TITLE
Show Login/Create Account in title bar instead of New Case

### DIFF
--- a/heat-stack/app/root.tsx
+++ b/heat-stack/app/root.tsx
@@ -192,7 +192,15 @@ function App() {
 		}
 	})
 	const caseId = matches.find((m) => m.params?.caseId)?.params?.caseId
-	const caseLabel = caseId ? `Case ${caseId}` : 'New Case'
+	const currentPath = data.requestInfo.path
+	const caseLabel =
+		currentPath === '/login'
+			? 'Login'
+			: currentPath === '/signup'
+				? 'Create Account'
+				: caseId
+					? `Case ${caseId}`
+					: 'New Case'
 	useToast(data.toast)
 	console.log('Home page rendered.')
 


### PR DESCRIPTION
Fixes #752 - the title banner is rendered globally in root.tsx and defaulted to 'New Case' for any route without a caseId param, which incorrectly applied to /login and /signup. Now checks the path and shows 'Login' / 'Create Account' respectively.