### PR TITLE
fix/750/fix_example_file_button

### DIFF
--- a/heat-stack/app/components/ui/CustomFileUpload.tsx
+++ b/heat-stack/app/components/ui/CustomFileUpload.tsx
@@ -36,7 +36,12 @@ export function CustomFileUpload({ name }: { name: string }) {
 
 				{/* Display filename */}
 				<span className="text-sm">{fileName}</span>
-
+				<a
+					className="ml-3 inline-flex items-center gap-1 rounded-md border border-transparent bg-secondary px-2.5 py-0.5 text-xs font-semibold text-secondary-foreground transition-colors hover:bg-secondary/80 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+					href="https://heatsmartalliance.org/wp-content/uploads/2026/07/HEAT-demo-gas-usage.csv"
+				>
+					Get demo CSV file
+				</a>
 				{/* Help icon immediately after filename */}
 				<HelpButton keyName="download.help" />
 			</div>

--- a/heat-stack/app/components/ui/heat/CaseSummaryComponents/EnergyUseUpload.tsx
+++ b/heat-stack/app/components/ui/heat/CaseSummaryComponents/EnergyUseUpload.tsx
@@ -69,7 +69,7 @@ export function EnergyUseUpload({
 
 				<a
 					className="ml-3 inline-flex items-center gap-1 rounded-md border border-transparent bg-secondary px-2.5 py-0.5 text-xs font-semibold text-secondary-foreground transition-colors hover:bg-secondary/80 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-					href="https://github.com/codeforboston/home-energy-analysis-tool/issues/162#issuecomment-2246594484"
+					href="https://heatsmartalliance.org/wp-content/uploads/2026/07/HEAT-demo-gas-usage.csv"
 				>
 					Get example file here
 				</a>

--- a/heat-stack/app/components/ui/heat/CaseSummaryComponents/EnergyUseUpload.tsx
+++ b/heat-stack/app/components/ui/heat/CaseSummaryComponents/EnergyUseUpload.tsx
@@ -66,13 +66,6 @@ export function EnergyUseUpload({
 						Calculate
 					</Button>
 				)}
-
-				<a
-					className="ml-3 inline-flex items-center gap-1 rounded-md border border-transparent bg-secondary px-2.5 py-0.5 text-xs font-semibold text-secondary-foreground transition-colors hover:bg-secondary/80 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-					href="https://heatsmartalliance.org/wp-content/uploads/2026/07/HEAT-demo-gas-usage.csv"
-				>
-					Get example file here
-				</a>
 			</div>
 		</fieldset>
 	)


### PR DESCRIPTION
closes #750

This just replaces the link to the GitHub issue to the new download link Steve provided.

<img width="399" height="251" alt="Recording 2026-07-14 at 22 20 16" src="https://github.com/user-attachments/assets/00f5ce4e-720d-43b8-a63f-aad9316deb90" />
