### PR TITLE
Prevent help buttons breaking calcuated results

### DIFF
--- a/heat-stack/app/components/ui/HelpButton.tsx
+++ b/heat-stack/app/components/ui/HelpButton.tsx
@@ -21,6 +21,7 @@ export function HelpButton({
 			<button
 				onClick={() => setModalOpen(true)}
 				className={`text-sm ${className ?? ''}`}
+				type="button"
 				{...rest}
 			>
 				<HelpCircle size={size} /> {/* 18px icon size */}


### PR DESCRIPTION
Closes Pressing "help" circles causes results to disappear, leaving error and successful save messages

Fixes #773