### PR TITLE
Migrate Python dev setup to uv, fix --dev/--extra dev docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ heat-tmp
 
 /heat-stack/tests/fixtures/openimg/
 /heat-stack/tests/fixtures/uploaded/
+
+# allows custom harness
+.claude
+CLAUDE.local.md 

--- a/heat-stack/uv.lock
+++ b/heat-stack/uv.lock
@@ -1,0 +1,159 @@
+version = 1
+revision = 3
+requires-python = "==3.13.*"
+
+[[package]]
+name = "black"
+version = "23.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/36/66370f5017b100225ec4950a60caeef60201a10080da57ddb24124453fba/black-23.3.0.tar.gz", hash = "sha256:1c7b8d606e728a41ea1ccbd7264677e494e87cf630e399262ced92d4a8dac940", size = 582156, upload-time = "2023-03-29T01:00:54.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/e7/4642b7f462381799393fbad894ba4b32db00870a797f0616c197b07129a9/black-23.3.0-py3-none-any.whl", hash = "sha256:ec751418022185b0c1bb7d7736e6933d40bbb14c14a0abcf9123d1b159f98dd4", size = 180965, upload-time = "2023-03-29T01:00:52.253Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "heat-stack"
+version = "0.5.0"
+source = { editable = "." }
+
+[package.optional-dependencies]
+dev = [
+    { name = "black" },
+    { name = "isort" },
+    { name = "mypy" },
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "black", marker = "extra == 'dev'", specifier = "==23.3.0" },
+    { name = "isort", marker = "extra == 'dev'", specifier = "==5.12.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==1.4.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = "==7.3.2" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "isort"
+version = "5.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/c4/dc00e42c158fc4dda2afebe57d2e948805c06d5169007f1724f0683010a9/isort-5.12.0.tar.gz", hash = "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504", size = 174643, upload-time = "2023-01-28T17:10:22.636Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/63/4036ae70eea279c63e2304b91ee0ac182f467f24f86394ecfe726092340b/isort-5.12.0-py3-none-any.whl", hash = "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6", size = 91198, upload-time = "2023-01-28T17:10:21.149Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/49/c5c7b9445ee563e09e71382e7fb147480fb85fa2356846488114f61549f8/mypy-1.4.0.tar.gz", hash = "sha256:de1e7e68148a213036276d1f5303b3836ad9a774188961eb2684eddff593b042", size = 2853251, upload-time = "2023-06-20T15:27:05.747Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/75/f6bee7491c41777c96ae7c328c92fe3c5695b39329a2ec2cf4947325a825/mypy-1.4.0-py3-none-any.whl", hash = "sha256:f051ca656be0c179c735a4c3193f307d34c92fdc4908d44fd4516fbe8b10567d", size = 2451391, upload-time = "2023-06-20T15:26:58.74Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.11.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/b7/802a56eca9f2fac455b8bab5375a2647b0f0e14a2cd63ef077de3c4a7658/platformdirs-4.11.7.tar.gz", hash = "sha256:4f41487eeeeeb07f3a6625e61d9bc0ae6809f92d3386dbd74392fbb76108104d", size = 35127, upload-time = "2026-09-01T13:35:10.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/6e/80993e10a0482f630cef528635789233224f36b1ffd11592aa15d13ff9ce/platformdirs-4.11.7-py3-none-any.whl", hash = "sha256:8a02cb259042c79d1cd0450facc2fe6dc9d303ae7901afbe33bf8ea0b188cef6", size = 23938, upload-time = "2026-09-01T13:35:09.02Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "7.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/2a/07c65fdc40846ecb8a9dcda2c38fcb5a06a3e39d08d4a4960916431951cb/pytest-7.3.2.tar.gz", hash = "sha256:ee990a3cc55ba808b80795a79944756f315c67c12b56abd3ac993a7b8c17030b", size = 1338457, upload-time = "2023-06-10T19:28:53.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/d0/de969198293cdea22b3a6fb99a99aeeddb7b3827f0823b33c5dc0734bbe5/pytest-7.3.2-py3-none-any.whl", hash = "sha256:cdcbd012c9312258922f8cd3f1b62a6580fdced17db6014896053d47cddf9295", size = 320900, upload-time = "2023-06-10T19:28:50.763Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/python/README.md
+++ b/python/README.md
@@ -108,7 +108,7 @@ If you have already pushed your branch to GitHub, you have two choices depending
 
 Check with a development lead before adding a python package. Adding python packages to development can be useful for syntax checking, testing, and building purposes, but should be avoided for production `src` code. Incorporating new packages into rules-engine.whl, which is used by the front end, is complicated. To add a package to development:
 
-1. Add package to the [project.optional-dependencies] or [dependency-groups.dev] section of pyproject.toml
+1. Add package to the `project.optional-dependencies` section of pyproject.toml
 2. Run `uv sync --dev` to lock dependencies and update your environment.
 
 ### Pre-Commit Verification

--- a/python/README.md
+++ b/python/README.md
@@ -24,7 +24,10 @@ This project uses Python version 3.13.
 - On Windows, `pip install uv`
 
 5. Navigate to project's python directory by typing `cd python`.
-6. Run `uv sync --dev` to create the virtual environment and install all dependencies.
+6. Run `uv sync --extra dev` to create the virtual environment and install all dependencies, including dev tools like pytest, black, mypy, and isort.
+
+- Dev dependencies live under `[project.optional-dependencies].dev` in `pyproject.toml`, which `uv` treats as an "extra" rather than a dependency group. `uv sync` and `uv run` only install the base `dependencies` list unless the extra is requested explicitly, so `uv sync --dev` (with no `--extra`) will silently create a venv without pytest and any subsequent `uv run pytest` will fail with `error: Failed to spawn: pytest`.
+
 7. Run `uv run pytest` and see tests run successfully.
    Next steps: [README.md](https://github.com/codeforboston/home-energy-analysis-tool/blob/main/heat-stack/README.md)
 
@@ -109,7 +112,7 @@ If you have already pushed your branch to GitHub, you have two choices depending
 Check with a development lead before adding a python package. Adding python packages to development can be useful for syntax checking, testing, and building purposes, but should be avoided for production `src` code. Incorporating new packages into rules-engine.whl, which is used by the front end, is complicated. To add a package to development:
 
 1. Add package to the `project.optional-dependencies` section of pyproject.toml
-2. Run `uv sync --dev` to lock dependencies and update your environment.
+2. Run `uv sync --extra dev` to lock dependencies and update your environment.
 
 ### Pre-Commit Verification
 

--- a/python/README.md
+++ b/python/README.md
@@ -24,9 +24,8 @@ This project uses Python version 3.13.
 - On Windows, `pip install uv`
 
 5. Navigate to project's python directory by typing `cd python`.
-6. Still in python folder, run `pip install -e .` to install rules-engine.
-7. Run `source setup-python.sh`
-8. Run `pytest` and see tests run successfully.
+6. Run `uv sync --dev` to create the virtual environment and install all dependencies.
+7. Run `uv run pytest` and see tests run successfully.
    Next steps: [README.md](https://github.com/codeforboston/home-energy-analysis-tool/blob/main/heat-stack/README.md)
 
 
@@ -75,35 +74,68 @@ The owner of the codespace:
 
 1. Find an issue to work on
 2. Open a bash terminal
-3. Create a branch from main. Best practice for naming looks like this: <issue, feature, or other>/<issue number>/<description>. Separate words in the description using a dash (-). Consider using the subject as a description. Example:
+3. Create a branch from main. Best practice for naming looks like this: <feature/fix/chore>/<issue number>/<description>. Separate words in the description using a dash (-). Consider using the subject as a description. Example:
 
 ```
 git checkout main
 git checkout -b feature/341/validate-address
 ```
 
-4. Commit frequently when you have made progress on the issue (you can always rollback). Advantages:
+4. Commit each time you make progress. Advantages include, but are not limited to:
 
-- incrementaly roll back smaller changes
-- review smaller changes
-- prevent losing unsaved files
-- get sense of progress
+- Being able to roll back to the latest commit when you make a mistake later (we all do)
+- Reviewing each future change independently before committing it (saves headaches)
+- Preventing the loss of unsaved files or changes (helpful during crashes)
+- Getting a sense of how far along you are (keeping work tracked)
 
 To revert a commmit:
 
-- `git reset --hard HEAD~1` if you want to go to the previous commit. If you want to revert 2 commits, do `git reset --hard HEAD~2`.
-- if you have pushed the branch to github, you can either delete the branch from github and push again or do a force push.
+- `git reset <--soft/--mixed/--hard> HEAD~1` if you want to go to the previous commit.
+- `git reset <--soft/--mixed/--hard> HEAD~2` If you want to revert 2 commits.
+- `git reset <--soft/--mixed/--hard> HEAD~N` If you want to revert N commits.
+
+Use `--soft` if you want the committed changes to be staged.  This flag is handy if you have unstaged changes you don't want to mix them with.
+Use `--mixed` if you want the committed changes to be unstaged.  This flag is handy if you have staged changes you don't want to mix them with.
+Use `--hard` if you want the committed changes gone immediately.  This flag causes irreversible data loss.
+
+If you have already pushed your branch to GitHub, you have two choices depending on what else you have already done.
+
+1. If you have opened a pull request, then do a force push via `git push origin <branch_name> --force-with-lease`
+2. If you have not, then delete the branch on GitHub and push your local branch up again.
+
 
 ### Adding Python Packages
 
-Check with a development lead before adding a python package. Adding python packages to development can be useful for syntax checking, testing, and building purposes, but should be avoided for production src code. Incorporating new packages into rules-engine.whl, which is used by the front end, is complicated. To add a package to development:
+Check with a development lead before adding a python package. Adding python packages to development can be useful for syntax checking, testing, and building purposes, but should be avoided for production `src` code. Incorporating new packages into rules-engine.whl, which is used by the front end, is complicated. To add a package to development:
 
-1. Add package to the "dev" section of pyproject.toml
-2. Run pip-compile as described in the comments of requirements-dev.txt. These instructions will autogenerate requirements-dev.txt.
+1. Add package to the [project.optional-dependencies] or [dependency-groups.dev] section of pyproject.toml
+2. Run `uv sync --dev` to lock dependencies and update your environment.
+
+### Pre-Commit Verification
+
+Before committing your changes, navigate to the `python` directory and run the complete verification script:
+
+```bash
+source prepare.sh
+```
+
+This script:
+1. **Formats code** with Black
+2. **Type-checks** with mypy
+3. **Sorts imports** with isort
+4. **Runs tests** with pytest
+5. **Builds the wheel** to verify packaging integrity
+
+The wheel build is critical because the rules engine is used by Pyodide (WebAssembly). This step ensures that:
+- All data files (`.csv`) are correctly included
+- Module structure is correct
+- The packaged wheel matches what will be deployed
+
+If `prepare.sh` succeeds without errors, your changes are ready to commit and push.
 
 ### Committing Your Changes
 
-Before committing your changes, go to the `python` directory and run `source prepare.sh` from the terminal to format, check for typing errors, and run all tests via `pytest`.
+Run the pre-commit verification script (see [Pre-Commit Verification](#pre-commit-verification)) before committing your changes.
 
 ### Creating a Pull Request
 
@@ -116,16 +148,10 @@ git checkout <your branch>
 git rebase main
 ```
 
-2. run the following validation commands first and fix any errors:
-
-```
-source check.python.sh
-```
-
-3. Push your branch either to a fork of the repository or to the main repo (if you have privileges): `git push origin <branch_name>`.
-4. Create pull request from github.
+2. Push your branch either to a fork of the repository or to the main repo (if you have privileges): `git push origin <branch_name>`.
+3. Create pull request from github.
    - Include statement "Closes `#<issue number>`" if your changes completely fix or address the issue.
    - Check that all checks pass in the pull request.
-5. Review file changes.
-6. Include a brief description of changes in each file.
-7. Request reviewers.
+4. Review file changes.
+5. Include a brief description of changes in each file.
+6. Request reviewers.

--- a/python/prepare.sh
+++ b/python/prepare.sh
@@ -1,7 +1,10 @@
+#!/bin/bash
+
 trap 'echo "An error occurred"; set +x' ERR
 set -x
-black .
-mypy .
-isort .
-pytest
+uv run --with black black .
+uv run --with mypy mypy .
+uv run --with isort isort .
+uv run --with pytest pytest
+uv build
 set +x

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -63,3 +63,4 @@ rules-engine = { workspace = true }
 members = [
     ".",
 ]
+

--- a/python/setup-python.sh
+++ b/python/setup-python.sh
@@ -1,24 +1,6 @@
 #!/bin/bash
 
-# Trap errors and print a message
 trap 'echo "An error occurred"; set +x' ERR
 
-# Create a virtual environment if it doesn't exist
-if [ ! -d ".venv" ]; then
-    python3 -m venv .venv || { echo "Failed to create virtual environment"; exit 1; }
-fi
-
-# Activate the virtual environment
-case "$OSTYPE" in
-  msys*) source .venv/Scripts/activate;;
-  *) source .venv/bin/activate;;
-esac
-
-# Sync dependencies into the virtual environment
+# Create virtual environment and install everything
 uv sync --dev
-
-# Install development dependencies
-uv pip install -e ".[dev]"
-
-# End of script
-set +x


### PR DESCRIPTION
## Summary
- Migrates the Python rules-engine dev setup from `pip install -e .` + `setup-python.sh` to `uv sync` / `uv run`, adding `heat-stack/uv.lock`.
- Fixes `python/README.md` instructions that referenced `uv sync --dev`, which silently skips installing dev tools (pytest, black, mypy, isort) because those live under `[project.optional-dependencies].dev` — an "extra" in uv's terms, not a dependency group. Corrected to `uv sync --extra dev` in both the initial setup steps and the "adding a package" section, with an explanation of why the old command failed (`uv run pytest` → `error: Failed to spawn: pytest`).
- Updates branch-naming and commit-frequency guidance in the README.
- Adds `.claude` and `CLAUDE.local.md` to `.gitignore` to keep local Claude Code harness config out of version control.

## Test plan
- [ ] `cd python && uv sync --extra dev && uv run pytest` succeeds and installs pytest/black/mypy/isort