### PR TITLE
chore: Enforce linting and tests at both pre-commit and pre-push stages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,16 +3,19 @@ repos:
     rev: 24.4.2
     hooks:
       - id: black
+        stages: [pre-commit, pre-push]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.10.0
     hooks:
       - id: mypy
-        args: [“--config-file=mypy.ini”]
+        args: ["--config-file=mypy.ini"]
         files: ^heat-stack/python/
+        stages: [pre-commit, pre-push]
   - repo: https://github.com/pre-commit/mirrors-isort
     rev: v5.10.1
     hooks:
       - id: isort
+        stages: [pre-commit, pre-push]
   - repo: local
     hooks:
       - id: prettier
@@ -20,10 +23,19 @@ repos:
         entry: bash -c 'cd heat-stack && exec ./node_modules/.bin/prettier --check "${@#heat-stack/}"' --
         language: system
         files: ^heat-stack/.*\.(css|js|jsx|json|md|ts|tsx|yaml|yml)$
+        stages: [pre-commit, pre-push]
       - id: pytest
         name: pytest before push
         entry: pytest
         language: system
         types: [python]
-        stages: [pre-push]
         exclude: ^heat-stack/app/pycode/
+        stages: [pre-commit, pre-push]
+  - repo: local
+    hooks:
+      - id: uv-build
+        name: uv build
+        entry: uv build
+        language: system
+        stages: [pre-commit, pre-push]
+        files: ^heat-stack/python/


### PR DESCRIPTION
## Problem
Our pre-commit hooks only catch issues after `git commit`, and some checks (like pytest) were gated to pre-push only. This creates two problems: developers can `--no-verify` at commit time and completely skip validation, and late-stage checks (pre-push) mean slow feedback loops when developers discover issues they could have caught earlier.

## Solution
Unified all linting, formatting, and type-checking hooks to run at both pre-commit and pre-push stages. This ensures:
- Fast feedback at commit time (black, mypy, isort, prettier)
- Comprehensive validation before push (pytest, uv-build)
- Added uv-build hook to catch package build failures before they reach CI/CD

## Impact
- Developers get immediate feedback on formatting and type errors while editing
- pytest now runs early in the workflow, catching logic errors before the final push
- uv-build integration catches dependency and build issues locally, reducing CI/CD failures
- Pre-push stage acts as a final safety net, reducing `--no-verify` temptation
- Shifts left on quality checks while maintaining a strong validation gate before code reaches the team